### PR TITLE
Upgrade deps to resolve all security vulnerabilities

### DIFF
--- a/app/AutoListbox.tsx
+++ b/app/AutoListbox.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { Autocomplete, AutocompleteItem } from "@nextui-org/react";
+import { Autocomplete, AutocompleteItem } from "@heroui/react";
 
 export default function AutoListbox({
   data,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import Header from "./Header";
 import AutoListbox from "./AutoListbox";
 
 export default async function Index() {
-  const supabase = createClient();
+  const supabase = await createClient();
 
   const { data: issues } = await supabase.from("issues").select("name");
   // const { data: notes } = await supabase.from('legislator_issue').select().order('id', {ascending:true})

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,23 +5,23 @@
   "packages": {
     "": {
       "dependencies": {
-        "@nextui-org/react": "^2.2.10",
+        "@heroui/react": "^2.8.10",
         "@supabase/ssr": "latest",
         "@supabase/supabase-js": "latest",
         "autoprefixer": "10.4.17",
-        "framer-motion": "^11.0.28",
+        "framer-motion": "^11.5.6",
         "geist": "^1.2.1",
-        "next": "^14.2.1",
+        "next": "^15.5.12",
         "postcss": "8.4.33",
-        "react": "18.2.0",
-        "react-dom": "18.2.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "tailwindcss": "3.4.1",
         "typescript": "5.3.3"
       },
       "devDependencies": {
         "@types/node": "20.11.5",
-        "@types/react": "18.2.48",
-        "@types/react-dom": "18.2.18",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
         "encoding": "^0.1.13"
       }
     },
@@ -29,6 +29,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -37,164 +38,2201 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
-      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.2.tgz",
-      "integrity": "sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==",
+    "node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@formatjs/intl-localematcher": "0.5.4",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.0.tgz",
-      "integrity": "sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.7.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.6.tgz",
-      "integrity": "sha512-etVau26po9+eewJKYoiBKP6743I1br0/Ie00Pb/S/PtmYfmjTcOn2YCh2yNkSZI12h6Rg+BOgQYborXk46BvkA==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.2",
-        "@formatjs/icu-skeleton-parser": "1.8.0",
-        "tslib": "^2.4.0"
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.0.tgz",
-      "integrity": "sha512-QWLAYvM0n8hv7Nq5BEs4LKIjevpVpbGLAJgOaYzg9wABEoX1j0JO1q2/jVkO6CVlq0dbsxZCngS5aXbysYueqA==",
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.2",
-        "tslib": "^2.4.0"
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz",
-      "integrity": "sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "license": "MIT",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@heroui/aria-utils": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/@heroui/aria-utils/-/aria-utils-2.2.29.tgz",
+      "integrity": "sha512-tVc5Rz+u/WMaAoYpx4VNheFqsfxA5i0SAqT8OAFpPX0WiNrylXaAGWsid/ivFdlW4rE1FgI/+wP0KS6c8KSEjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/system": "2.4.28",
+        "@react-aria/utils": "3.33.1",
+        "@react-stately/collections": "3.12.10",
+        "@react-types/overlays": "3.9.4",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/dom-animation": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@heroui/dom-animation/-/dom-animation-2.1.10.tgz",
+      "integrity": "sha512-dt+0xdVPbORwNvFT5pnqV2ULLlSgOJeqlg/DMo97s9RWeD6rD4VedNY90c8C9meqWqGegQYBQ9ztsfX32mGEPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1"
+      }
+    },
+    "node_modules/@heroui/form": {
+      "version": "2.1.32",
+      "resolved": "https://registry.npmjs.org/@heroui/form/-/form-2.1.32.tgz",
+      "integrity": "sha512-gcMnlNq2eI8jIvNIEas4HVmQNdkRuZnhRCx/nZOd/FtO+WQwuqN2xFAfm/nGH3Hq/7yRf2yOozuJsm7iJVaatA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/system": "2.4.28",
+        "@heroui/theme": "2.4.26",
+        "@react-stately/form": "3.2.4",
+        "@react-types/form": "3.7.18",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@heroui/form/node_modules/@heroui/theme": {
+      "version": "2.4.26",
+      "resolved": "https://registry.npmjs.org/@heroui/theme/-/theme-2.4.26.tgz",
+      "integrity": "sha512-TYatChq7YyGDcPJytgOMqQwK72qWYb+vIa7mLmX3Cu9+JzFs2VSHu2QqzdhnOHoK0uJr8giDMy0gvJEDuu31vw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.12",
+        "color": "^4.2.3",
+        "color2k": "^2.0.3",
+        "deepmerge": "4.3.1",
+        "tailwind-merge": "3.4.0",
+        "tailwind-variants": "3.2.2"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=4.0.0"
+      }
+    },
+    "node_modules/@heroui/form/node_modules/tailwindcss": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
+      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@heroui/framer-utils": {
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/@heroui/framer-utils/-/framer-utils-2.1.28.tgz",
+      "integrity": "sha512-/M2nqHRx4feZx0lgA8QmHDaqu/DgsdynvSnbniptiU/Xi9XgQApCPJ0Qxgk5JZ9g2vemDFgi5AP7C7FqgiMtMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/system": "2.4.28",
+        "@heroui/use-measure": "2.1.8"
+      },
+      "peerDependencies": {
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/@heroui/react/-/react-2.8.10.tgz",
+      "integrity": "sha512-rW5wFxLX3SNusf8Uhq10M5btRplKunU8glU1Gd4gD9AMIV/e7D+DGy/g2ildz2gEcMPny4C5kLcYlwRDea5oNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/accordion": "2.2.29",
+        "@heroui/alert": "2.2.32",
+        "@heroui/autocomplete": "2.3.34",
+        "@heroui/avatar": "2.2.26",
+        "@heroui/badge": "2.2.18",
+        "@heroui/breadcrumbs": "2.2.25",
+        "@heroui/button": "2.2.32",
+        "@heroui/calendar": "2.2.32",
+        "@heroui/card": "2.2.28",
+        "@heroui/checkbox": "2.3.32",
+        "@heroui/chip": "2.2.25",
+        "@heroui/code": "2.2.25",
+        "@heroui/date-input": "2.3.32",
+        "@heroui/date-picker": "2.3.33",
+        "@heroui/divider": "2.2.24",
+        "@heroui/drawer": "2.2.29",
+        "@heroui/dropdown": "2.3.32",
+        "@heroui/form": "2.1.32",
+        "@heroui/framer-utils": "2.1.28",
+        "@heroui/image": "2.2.19",
+        "@heroui/input": "2.4.33",
+        "@heroui/input-otp": "2.1.32",
+        "@heroui/kbd": "2.2.26",
+        "@heroui/link": "2.2.26",
+        "@heroui/listbox": "2.3.31",
+        "@heroui/menu": "2.2.31",
+        "@heroui/modal": "2.2.29",
+        "@heroui/navbar": "2.2.30",
+        "@heroui/number-input": "2.0.23",
+        "@heroui/pagination": "2.2.27",
+        "@heroui/popover": "2.3.32",
+        "@heroui/progress": "2.2.25",
+        "@heroui/radio": "2.3.32",
+        "@heroui/ripple": "2.2.21",
+        "@heroui/scroll-shadow": "2.3.19",
+        "@heroui/select": "2.4.33",
+        "@heroui/skeleton": "2.2.18",
+        "@heroui/slider": "2.4.29",
+        "@heroui/snippet": "2.2.33",
+        "@heroui/spacer": "2.2.25",
+        "@heroui/spinner": "2.2.29",
+        "@heroui/switch": "2.2.27",
+        "@heroui/system": "2.4.28",
+        "@heroui/table": "2.2.32",
+        "@heroui/tabs": "2.2.29",
+        "@heroui/theme": "2.4.26",
+        "@heroui/toast": "2.0.22",
+        "@heroui/tooltip": "2.2.29",
+        "@heroui/user": "2.2.26",
+        "@react-aria/visually-hidden": "3.8.31"
+      },
+      "peerDependencies": {
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react-rsc-utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@heroui/react-rsc-utils/-/react-rsc-utils-2.1.9.tgz",
+      "integrity": "sha512-e77OEjNCmQxE9/pnLDDb93qWkX58/CcgIqdNAczT/zUP+a48NxGq2A2WRimvc1uviwaNL2StriE2DmyZPyYW7Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react-utils": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/@heroui/react-utils/-/react-utils-2.1.14.tgz",
+      "integrity": "sha512-hhKklYKy9sRH52C9A8P0jWQ79W4MkIvOnKBIuxEMHhigjfracy0o0lMnAUdEsJni4oZKVJYqNGdQl+UVgcmeDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-rsc-utils": "2.1.9",
+        "@heroui/shared-utils": "2.1.12"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/accordion": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/@heroui/accordion/-/accordion-2.2.29.tgz",
+      "integrity": "sha512-nhCqgZ3ejgRLRM3jJnpZExufn050raxOVyNUR7zo9o5Ed10KKRpD3J/8l6gwrYA7j+Z46dF2YLJzIFWPzYf1Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/divider": "2.2.24",
+        "@heroui/dom-animation": "2.1.10",
+        "@heroui/framer-utils": "2.1.28",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-aria-accordion": "2.2.20",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-stately/tree": "3.9.6",
+        "@react-types/accordion": "3.0.0-alpha.26",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/alert": {
+      "version": "2.2.32",
+      "resolved": "https://registry.npmjs.org/@heroui/alert/-/alert-2.2.32.tgz",
+      "integrity": "sha512-8piby1PXVTTtdwLLV60JMqduRAFLHoiQpFPeSNVHsAaMIphXsmlpvUb9dct4f0wQJqqgFutiWL3RtjdDwEkRQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/button": "2.2.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@react-stately/utils": "3.11.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/autocomplete": {
+      "version": "2.3.34",
+      "resolved": "https://registry.npmjs.org/@heroui/autocomplete/-/autocomplete-2.3.34.tgz",
+      "integrity": "sha512-DTmztrWMdEtHCIJmgSyO/7QrABsaq/kDqBg6aVw+P30sgLW6k05wYOqe6ctuoNSWaZzr56QPvFpsgbeMy7Ma0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/button": "2.2.32",
+        "@heroui/form": "2.1.32",
+        "@heroui/input": "2.4.33",
+        "@heroui/listbox": "2.3.31",
+        "@heroui/popover": "2.3.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/scroll-shadow": "2.3.19",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-safe-layout-effect": "2.1.8",
+        "@react-aria/combobox": "3.15.0",
+        "@react-aria/i18n": "3.12.16",
+        "@react-stately/combobox": "3.13.0",
+        "@react-types/combobox": "3.14.0",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/avatar": {
+      "version": "2.2.26",
+      "resolved": "https://registry.npmjs.org/@heroui/avatar/-/avatar-2.2.26.tgz",
+      "integrity": "sha512-W2z64Da38ZL4Lu9Pokan2frTURcXxUs3bV37WWJjMzCD6mOAlaogWYMQdAeYmeWHyAW18XZSa5OaUCMVrzJ2SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-image": "2.1.14",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/badge": {
+      "version": "2.2.18",
+      "resolved": "https://registry.npmjs.org/@heroui/badge/-/badge-2.2.18.tgz",
+      "integrity": "sha512-OfGove8YJ9oDrdugzq05FC15ZKD5nzqe+thPZ+1SY1LZorJQjZvqSD9QnoEH1nG7fu2IdH6pYJy3sZ/b6Vj5Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.23",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/breadcrumbs": {
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/@heroui/breadcrumbs/-/breadcrumbs-2.2.25.tgz",
+      "integrity": "sha512-KmUmJiBVzRuKR1tXIvKBqz8rGz4jAPa2FqsDodQ/Z34Eagsw85l3pI6xekKacGcxNQVM+L6KhMRb00QWHT/SmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@react-aria/breadcrumbs": "3.5.32",
+        "@react-aria/focus": "3.21.5",
+        "@react-types/breadcrumbs": "3.7.19"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/button": {
+      "version": "2.2.32",
+      "resolved": "https://registry.npmjs.org/@heroui/button/-/button-2.2.32.tgz",
+      "integrity": "sha512-i1vx4gEuyjKmz0xVu+U3PgtYrsGt1PVuWBrT/sSbNcH0AGuPSqQPQ/znwkhgZ4ixhNaU9jjVbBfIGCFGNDz7XA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/ripple": "2.2.21",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/spinner": "2.2.29",
+        "@heroui/use-aria-button": "2.2.22",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/calendar": {
+      "version": "2.2.32",
+      "resolved": "https://registry.npmjs.org/@heroui/calendar/-/calendar-2.2.32.tgz",
+      "integrity": "sha512-2xzCmM7Sdz04qYr478lcH3GfGi2HWmKZ77PXrxWyRcVys+6GQpJJS712eusQBdoDNoUHUK/qZLTxihwiDC46wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/button": "2.2.32",
+        "@heroui/dom-animation": "2.1.10",
+        "@heroui/framer-utils": "2.1.28",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-aria-button": "2.2.22",
+        "@internationalized/date": "3.12.0",
+        "@react-aria/calendar": "3.9.5",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/i18n": "3.12.16",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/visually-hidden": "3.8.31",
+        "@react-stately/calendar": "3.9.3",
+        "@react-stately/utils": "3.11.0",
+        "@react-types/button": "3.15.1",
+        "@react-types/calendar": "3.8.3",
+        "@react-types/shared": "3.33.1",
+        "scroll-into-view-if-needed": "3.0.10"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/card": {
+      "version": "2.2.28",
+      "resolved": "https://registry.npmjs.org/@heroui/card/-/card-2.2.28.tgz",
+      "integrity": "sha512-njwCocEntWaYyALB+2SHzVzoG4JJMV2rG55vQ0zZIIJoG1+/F9SCfsZQ87ncf+0D7IQx6vw8fWT2VRKojmn9+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/ripple": "2.2.21",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-aria-button": "2.2.22",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/checkbox": {
+      "version": "2.3.32",
+      "resolved": "https://registry.npmjs.org/@heroui/checkbox/-/checkbox-2.3.32.tgz",
+      "integrity": "sha512-rmFGPTgpG/Uvlr/8KjCSobT3u2Ig4/3p8s0qwTCo37uvtsCIbCYyB1yNAXZkCN2hfg5ZIBofEaYeEmw0OBsQAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/form": "2.1.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-callback-ref": "2.1.8",
+        "@heroui/use-safe-layout-effect": "2.1.8",
+        "@react-aria/checkbox": "3.16.5",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-stately/checkbox": "3.7.5",
+        "@react-stately/toggle": "3.9.5",
+        "@react-types/checkbox": "3.10.4",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/chip": {
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/@heroui/chip/-/chip-2.2.25.tgz",
+      "integrity": "sha512-kACEoF7tP9o/q5HdARaP3veD0Rl4Uxe9fiTVQvus8kN97Jnw9y4JctsUJ/vXgsscKt39qh53TB8fo8I0sJ2FPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/code": {
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/@heroui/code/-/code-2.2.25.tgz",
+      "integrity": "sha512-oGaQVktqTNqRPDceuV/egVh442Ap4cbuXxVSqsmT0aNV1KnISo/P7VwLm4QDN5T3MXxN3Cs2Pw6z0+oydPL3mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/system-rsc": "2.3.24"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/date-input": {
+      "version": "2.3.32",
+      "resolved": "https://registry.npmjs.org/@heroui/date-input/-/date-input-2.3.32.tgz",
+      "integrity": "sha512-jk0cPMkfs0lexdJckBZ4qO96tTqT3ZMgb+Z12aS8VW3Hcbvj2vvv2fuHc7LrIg1mdUqZzZwCwUAsUGWSJDTI0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/form": "2.1.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@internationalized/date": "3.12.0",
+        "@react-aria/datepicker": "3.16.1",
+        "@react-aria/i18n": "3.12.16",
+        "@react-stately/datepicker": "3.16.1",
+        "@react-types/datepicker": "3.13.5",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/date-picker": {
+      "version": "2.3.33",
+      "resolved": "https://registry.npmjs.org/@heroui/date-picker/-/date-picker-2.3.33.tgz",
+      "integrity": "sha512-u9N2NToMLg3hwn7WEXljhrtM/DiRrUVBqs35akW9gTQtcz1fGPugrDkJy4OsKEv7c1HuYBO0As6CM+uXERjHWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/button": "2.2.32",
+        "@heroui/calendar": "2.2.32",
+        "@heroui/date-input": "2.3.32",
+        "@heroui/form": "2.1.32",
+        "@heroui/popover": "2.3.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@internationalized/date": "3.12.0",
+        "@react-aria/datepicker": "3.16.1",
+        "@react-aria/i18n": "3.12.16",
+        "@react-stately/datepicker": "3.16.1",
+        "@react-stately/utils": "3.11.0",
+        "@react-types/datepicker": "3.13.5",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/divider": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/@heroui/divider/-/divider-2.2.24.tgz",
+      "integrity": "sha512-fq7bZFpruws3aC5X2TGMMUhcInyxQS6oWAOYrwgWX5jrmqzg/8CBtIuOehhwcm0HAk+oI55KFidJUFTuA1s7Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-rsc-utils": "2.1.9",
+        "@heroui/system-rsc": "2.3.24",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/drawer": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/@heroui/drawer/-/drawer-2.2.29.tgz",
+      "integrity": "sha512-zVBKHbcCXZGR79ORw4vQRA/QfHNLoQ9R8q6P1gsjs24uBGdBQAYvQE0F/bfsKZ5JH7asUt+oSIpjqQGmXAbyyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/framer-utils": "2.1.28",
+        "@heroui/modal": "2.2.29",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/dropdown": {
+      "version": "2.3.32",
+      "resolved": "https://registry.npmjs.org/@heroui/dropdown/-/dropdown-2.3.32.tgz",
+      "integrity": "sha512-+ntmjxkBaUVpyGN0pcByeTm2e2RUi5/D5uI9vPFLvJYWCa26bzQRR7EuK7LuGRXVciWl+NODNlLbSUVukkHBUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/menu": "2.2.31",
+        "@heroui/popover": "2.3.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/menu": "3.21.0",
+        "@react-stately/menu": "3.9.11",
+        "@react-types/menu": "3.10.7"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/image": {
+      "version": "2.2.19",
+      "resolved": "https://registry.npmjs.org/@heroui/image/-/image-2.2.19.tgz",
+      "integrity": "sha512-XdQ1g0kiHl+Kj9Zj1NL1mbKhmzeN0h27dgfegJS2coGM/yrEavYzg1DWUEyVSzPNKFZS8BDGa9DOpWe0vgggBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-image": "2.1.14"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/input": {
+      "version": "2.4.33",
+      "resolved": "https://registry.npmjs.org/@heroui/input/-/input-2.4.33.tgz",
+      "integrity": "sha512-iDKujnKgXDbR4zLVr03Pg3TYKFR2zv0aPZUpjOvtLdB8/wNBQv+rbizqnHQPAYyDwhNQS0WguW0tQVhh4oPy4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/form": "2.1.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-safe-layout-effect": "2.1.8",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/textfield": "3.18.5",
+        "@react-stately/utils": "3.11.0",
+        "@react-types/shared": "3.33.1",
+        "@react-types/textfield": "3.12.8",
+        "react-textarea-autosize": "^8.5.3"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/input-otp": {
+      "version": "2.1.32",
+      "resolved": "https://registry.npmjs.org/@heroui/input-otp/-/input-otp-2.1.32.tgz",
+      "integrity": "sha512-lrByjetK5/9MjqhDXHnhAI/gBnCJjMmR92k2HARjnJjYhljD58j6xYuf41zwp/faYkyspVvmLMPHF8qjKMTAbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/form": "2.1.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-form-reset": "2.0.1",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/form": "3.1.5",
+        "@react-stately/form": "3.2.4",
+        "@react-stately/utils": "3.11.0",
+        "@react-types/textfield": "3.12.8",
+        "input-otp": "1.4.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/kbd": {
+      "version": "2.2.26",
+      "resolved": "https://registry.npmjs.org/@heroui/kbd/-/kbd-2.2.26.tgz",
+      "integrity": "sha512-Z8XpQwMmNpLGlQlGD7UWRWG2S8veNb9vezfWgEKmtnnzdVM/CKSYTWctkmiruJ7tPn3XPsGTEt3QU8WPVAnpqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/system-rsc": "2.3.24"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/link": {
+      "version": "2.2.26",
+      "resolved": "https://registry.npmjs.org/@heroui/link/-/link-2.2.26.tgz",
+      "integrity": "sha512-TPxd87ZP8mB8HG0GVIDTuoDxL2mcpCVUY9sjrxujAtin3781znM6jFO+O/tv0huW90+jxBHiFU1KpeZWwtl6qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-aria-link": "2.2.23",
+        "@react-aria/focus": "3.21.5",
+        "@react-types/link": "3.6.7"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/listbox": {
+      "version": "2.3.31",
+      "resolved": "https://registry.npmjs.org/@heroui/listbox/-/listbox-2.3.31.tgz",
+      "integrity": "sha512-EvYxlama0kDCtgyNfCtz/X7ftYSE0OlPGKrZrv0st0oz790x3E1EQyCEYOaDbHAnGPxJy8pRC88CbzyPWEHeXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/divider": "2.2.24",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-is-mobile": "2.2.12",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/listbox": "3.15.3",
+        "@react-stately/list": "3.13.4",
+        "@react-types/shared": "3.33.1",
+        "@tanstack/react-virtual": "3.11.3"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/menu": {
+      "version": "2.2.31",
+      "resolved": "https://registry.npmjs.org/@heroui/menu/-/menu-2.2.31.tgz",
+      "integrity": "sha512-e5VqpMapolo51kJdHdz+tm3a++dGnvPTQtma8bFPfguVzoyzbq4eicFUR9fvbvYjP2jNewwsyaoTqBvxqbueiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/divider": "2.2.24",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-is-mobile": "2.2.12",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/menu": "3.21.0",
+        "@react-stately/tree": "3.9.6",
+        "@react-types/menu": "3.10.7",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/modal": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/@heroui/modal/-/modal-2.2.29.tgz",
+      "integrity": "sha512-ke6i2ByLuTE/4OZRZvgKv6A2Vf1GkitL/Lq+Bojq8ovIquphmH7AXrXkWEQ6yq1YdqYRDFcVOX/4p11Qjv4rkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/dom-animation": "2.1.10",
+        "@heroui/framer-utils": "2.1.28",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-aria-button": "2.2.22",
+        "@heroui/use-aria-modal-overlay": "2.2.21",
+        "@heroui/use-disclosure": "2.2.19",
+        "@heroui/use-draggable": "2.1.20",
+        "@heroui/use-viewport-size": "2.0.1",
+        "@react-aria/dialog": "3.5.34",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/overlays": "3.31.2",
+        "@react-stately/overlays": "3.6.23"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/navbar": {
+      "version": "2.2.30",
+      "resolved": "https://registry.npmjs.org/@heroui/navbar/-/navbar-2.2.30.tgz",
+      "integrity": "sha512-zGMRuewcjUFZhj3hIyIWOq+iRt0Mcc8FHBDPHAcYtYe0PrfYF2Ti0WLoH5Bbf5kR3S5hYfwabyT7jtf173S7iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/dom-animation": "2.1.10",
+        "@heroui/framer-utils": "2.1.28",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-resize": "2.1.8",
+        "@heroui/use-scroll-position": "2.1.8",
+        "@react-aria/button": "3.14.5",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/overlays": "3.31.2",
+        "@react-stately/toggle": "3.9.5",
+        "@react-stately/utils": "3.11.0"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/number-input": {
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/@heroui/number-input/-/number-input-2.0.23.tgz",
+      "integrity": "sha512-06Glv+X+tqSLt7i7MUJJz2Zf65+kkBaL/Cgx0Sw7iA418WejPDF3KIRee48RdfI+AOHYPAH4AD9PnGAaOJvapQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/button": "2.2.32",
+        "@heroui/form": "2.1.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-safe-layout-effect": "2.1.8",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/i18n": "3.12.16",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/numberfield": "3.12.5",
+        "@react-stately/numberfield": "3.11.0",
+        "@react-types/button": "3.15.1",
+        "@react-types/numberfield": "3.8.18",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/pagination": {
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/@heroui/pagination/-/pagination-2.2.27.tgz",
+      "integrity": "sha512-omTpyJwGzw2fmSdfCfJuIgVmTqDaMzs4RmDtjgqEZxZCAldFlVuTWmsR1peOwzZKsrhzbp3eH/E9F6ipwF6Yug==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-intersection-observer": "2.2.14",
+        "@heroui/use-pagination": "2.2.20",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/i18n": "3.12.16",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/utils": "3.33.1",
+        "scroll-into-view-if-needed": "3.0.10"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/popover": {
+      "version": "2.3.32",
+      "resolved": "https://registry.npmjs.org/@heroui/popover/-/popover-2.3.32.tgz",
+      "integrity": "sha512-aVkDt9aITI66x7nS0k2BJ7szQtNm5YV+Q31X9aWrXFkRdJ+zl0sMbo1UpVQdGSif0yH6NvsFTThmCWDQZkX6fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/button": "2.2.32",
+        "@heroui/dom-animation": "2.1.10",
+        "@heroui/framer-utils": "2.1.28",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-aria-button": "2.2.22",
+        "@heroui/use-aria-overlay": "2.0.6",
+        "@heroui/use-safe-layout-effect": "2.1.8",
+        "@react-aria/dialog": "3.5.34",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/overlays": "3.31.2",
+        "@react-stately/overlays": "3.6.23",
+        "@react-types/overlays": "3.9.4"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/progress": {
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/@heroui/progress/-/progress-2.2.25.tgz",
+      "integrity": "sha512-0aMuB3RaEheJPiQPUPRvwC1CkBG9qDRzRyUu6GT5QJfkFVmeB09NwQB4wec74qa1Ke+Yhj2KHfCVyBzYNqAifw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-is-mounted": "2.1.8",
+        "@react-aria/progress": "3.4.30",
+        "@react-types/progress": "3.5.18"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/radio": {
+      "version": "2.3.32",
+      "resolved": "https://registry.npmjs.org/@heroui/radio/-/radio-2.3.32.tgz",
+      "integrity": "sha512-R0Oj8sQ5NA5LqPkouGEHPetgZxa1p7XNf5teVv0nL+8A9tg4R8VDLvL50ezc0yXp18PmfHa61AoK5DSCnyesNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/form": "2.1.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/radio": "3.12.5",
+        "@react-aria/visually-hidden": "3.8.31",
+        "@react-stately/radio": "3.11.5",
+        "@react-types/radio": "3.9.4",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/ripple": {
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/@heroui/ripple/-/ripple-2.2.21.tgz",
+      "integrity": "sha512-wairSq9LnhbIqTCJmUlJAQURQ1wcRK/L8pjg2s3R/XnvZlPXHy4ZzfphiwIlTI21z/f6tH3arxv/g1uXd1RY0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/dom-animation": "2.1.10",
+        "@heroui/shared-utils": "2.1.12"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.23",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/scroll-shadow": {
+      "version": "2.3.19",
+      "resolved": "https://registry.npmjs.org/@heroui/scroll-shadow/-/scroll-shadow-2.3.19.tgz",
+      "integrity": "sha512-y5mdBlhiITVrFnQTDqEphYj7p5pHqoFSFtVuRRvl9wUec2lMxEpD85uMGsfL8OgQTKIAqGh2s6M360+VJm7ajQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-data-scroll-overflow": "2.2.13"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.23",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/select": {
+      "version": "2.4.33",
+      "resolved": "https://registry.npmjs.org/@heroui/select/-/select-2.4.33.tgz",
+      "integrity": "sha512-iWlczBmrHz2lIjyAneiiFtmgM+YWKLNIHL9dQnMghSAZWT9iCES5c3RuiggqE9k7DfPjHmgvVB24qeajnnXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/form": "2.1.32",
+        "@heroui/listbox": "2.3.31",
+        "@heroui/popover": "2.3.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/scroll-shadow": "2.3.19",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/spinner": "2.2.29",
+        "@heroui/use-aria-button": "2.2.22",
+        "@heroui/use-aria-multiselect": "2.4.21",
+        "@heroui/use-form-reset": "2.0.1",
+        "@heroui/use-safe-layout-effect": "2.1.8",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/form": "3.1.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/overlays": "3.31.2",
+        "@react-aria/visually-hidden": "3.8.31",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/skeleton": {
+      "version": "2.2.18",
+      "resolved": "https://registry.npmjs.org/@heroui/skeleton/-/skeleton-2.2.18.tgz",
+      "integrity": "sha512-7AjU5kjk9rqrKP9mWQiAVj0dow4/vbK5/ejh4jqdb3DZm7bM2+DGzfnQPiS0c2eWR606CgOuuoImpwDS82HJtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.12"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.23",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/slider": {
+      "version": "2.4.29",
+      "resolved": "https://registry.npmjs.org/@heroui/slider/-/slider-2.4.29.tgz",
+      "integrity": "sha512-JY3uPIShCFLWTbLLYQJJIT5TyLQsyqJHPcM66FprDxwLkf/Ne03jvf+SeieCKAbq/iw+GygTIfwmbSPzrp/yhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/tooltip": "2.2.29",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/i18n": "3.12.16",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/slider": "3.8.5",
+        "@react-aria/visually-hidden": "3.8.31",
+        "@react-stately/slider": "3.7.5"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/snippet": {
+      "version": "2.2.33",
+      "resolved": "https://registry.npmjs.org/@heroui/snippet/-/snippet-2.2.33.tgz",
+      "integrity": "sha512-BvoqKPRhdZyXvvPLxUoU0Fg5MzxMYdGWmJMS9gLT1Zv9A9ixua7kTFh9Z5NT9aNScRR9vhroaSQi1x39uCp+5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/button": "2.2.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/tooltip": "2.2.29",
+        "@heroui/use-clipboard": "2.1.9",
+        "@react-aria/focus": "3.21.5"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/spacer": {
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/@heroui/spacer/-/spacer-2.2.25.tgz",
+      "integrity": "sha512-XSw54osEkNaBykZXhZcFmvwqwuSKCGPFOd2AIR+vrMqcJg0IxWjpGIsexaT3P/LV1PuoTYkTJ8G3N5Wf4pZTUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/system-rsc": "2.3.24"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/spinner": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/@heroui/spinner/-/spinner-2.2.29.tgz",
+      "integrity": "sha512-08mWpL4+pdACcyzT5MjR0nSkKoWbab0oPzY+JHxIdPSSh3S8JJ7C8dUeV3Kj/15NRzzZlcTM3ClRCV8fdeGmuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/system": "2.4.28",
+        "@heroui/system-rsc": "2.3.24"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/switch": {
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/@heroui/switch/-/switch-2.2.27.tgz",
+      "integrity": "sha512-z23is+gtPkX29EpixY5ZLY1+NQaP+ueshuiXzdgD9SfCQLOSDYDWuFVdR8ZgfdDPyhP8xpOnJf6l9zfgXHD8Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-safe-layout-effect": "2.1.8",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/switch": "3.7.11",
+        "@react-aria/visually-hidden": "3.8.31",
+        "@react-stately/toggle": "3.9.5"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/system-rsc": {
+      "version": "2.3.24",
+      "resolved": "https://registry.npmjs.org/@heroui/system-rsc/-/system-rsc-2.3.24.tgz",
+      "integrity": "sha512-GEP3hh7j8wE56WdSAIdCcPQOMDdAYk9bSuQpGzXnkYSiSCJKroOyXbRmp9KF2VgpiMXGI0OlO51aj9JWoa+5Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/table": {
+      "version": "2.2.32",
+      "resolved": "https://registry.npmjs.org/@heroui/table/-/table-2.2.32.tgz",
+      "integrity": "sha512-cJ+XtBZOonSmkw7jrj0d9c8aIMdSGSZrBKS/1KZ7J9BTFPDW+ZoWwomgJHgZ31FQlr7dkYa7mZ2rf8LoGoOxRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/checkbox": "2.3.32",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/table": "3.17.11",
+        "@react-aria/visually-hidden": "3.8.31",
+        "@react-stately/table": "3.15.4",
+        "@react-stately/virtualizer": "4.4.6",
+        "@react-types/grid": "3.3.8",
+        "@react-types/table": "3.13.6",
+        "@tanstack/react-virtual": "3.11.3"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/tabs": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/@heroui/tabs/-/tabs-2.2.29.tgz",
+      "integrity": "sha512-TzCRXDqhdNsUxhO6sPdsbEt8m7KlkGwvJGvs4S/kHvJh1sKCItnnT0Z2FpZr6pLAqmHA6LO6Ow1phR5ACfNmug==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-is-mounted": "2.1.8",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/tabs": "3.11.1",
+        "@react-stately/tabs": "3.8.9",
+        "@react-types/shared": "3.33.1",
+        "scroll-into-view-if-needed": "3.0.10"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/theme": {
+      "version": "2.4.26",
+      "resolved": "https://registry.npmjs.org/@heroui/theme/-/theme-2.4.26.tgz",
+      "integrity": "sha512-TYatChq7YyGDcPJytgOMqQwK72qWYb+vIa7mLmX3Cu9+JzFs2VSHu2QqzdhnOHoK0uJr8giDMy0gvJEDuu31vw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.12",
+        "color": "^4.2.3",
+        "color2k": "^2.0.3",
+        "deepmerge": "4.3.1",
+        "tailwind-merge": "3.4.0",
+        "tailwind-variants": "3.2.2"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=4.0.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/toast": {
+      "version": "2.0.22",
+      "resolved": "https://registry.npmjs.org/@heroui/toast/-/toast-2.0.22.tgz",
+      "integrity": "sha512-eaayx0oJW0/imLyOhfjOdMx8FEKbWa8aKVvPNvXr3mXQbgzBEa+e147Xbh2CneG66we9C24JETE7QMLJ00popw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-icons": "2.1.10",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/spinner": "2.2.29",
+        "@heroui/use-is-mobile": "2.2.12",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/toast": "3.0.11",
+        "@react-stately/toast": "3.1.3"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/tooltip": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/@heroui/tooltip/-/tooltip-2.2.29.tgz",
+      "integrity": "sha512-PsHVC9XwjmbZpdu7o8TWSHENiCHCsoQpzpFJ3GYgnUULIhH5k69L/+5jiON9qG6k7+tL4RZS6pQPSbxDCf1acQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/aria-utils": "2.2.29",
+        "@heroui/dom-animation": "2.1.10",
+        "@heroui/framer-utils": "2.1.28",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@heroui/use-aria-overlay": "2.0.6",
+        "@heroui/use-safe-layout-effect": "2.1.8",
+        "@react-aria/overlays": "3.31.2",
+        "@react-aria/tooltip": "3.9.2",
+        "@react-stately/tooltip": "3.5.11",
+        "@react-types/overlays": "3.9.4",
+        "@react-types/tooltip": "3.5.2"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/@heroui/user": {
+      "version": "2.2.26",
+      "resolved": "https://registry.npmjs.org/@heroui/user/-/user-2.2.26.tgz",
+      "integrity": "sha512-3SESvOSYSVysSSwV1SR2QD8cOx6Fv/vVAXry/GmjLl9CSsA6HTlWoLy7TRtteGFqm3XRWVqjzCrcNGlvSmtdnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/avatar": "2.2.26",
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/shared-utils": "2.1.12",
+        "@react-aria/focus": "3.21.5"
+      },
+      "peerDependencies": {
+        "@heroui/system": ">=2.4.18",
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/react/node_modules/tailwindcss": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
+      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@heroui/shared-icons": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@heroui/shared-icons/-/shared-icons-2.1.10.tgz",
+      "integrity": "sha512-ePo60GjEpM0SEyZBGOeySsLueNDCqLsVL79Fq+5BphzlrBAcaKY7kUp74964ImtkXvknTxAWzuuTr3kCRqj6jg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/shared-utils": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@heroui/shared-utils/-/shared-utils-2.1.12.tgz",
+      "integrity": "sha512-0iCnxVAkIPtrHQo26Qa5g0UTqMTpugTbClNOrEPsrQuyRAq7Syux998cPwGlneTfB5E5xcU3LiEdA9GUyeK2cQ==",
+      "hasInstallScript": true,
+      "license": "MIT"
+    },
+    "node_modules/@heroui/system": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@heroui/system/-/system-2.4.28.tgz",
+      "integrity": "sha512-agtiiMFsCLaBrGWWrGBlFrnwi06ym4uouh61c3/m16CHuYfGm0Hx5oJ1mZVF98SJ91mDyU3e6Rv+8mqV9XVgoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/system-rsc": "2.3.24",
+        "@react-aria/i18n": "3.12.16",
+        "@react-aria/overlays": "3.31.2",
+        "@react-aria/utils": "3.33.1"
+      },
+      "peerDependencies": {
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/system/node_modules/@heroui/system-rsc": {
+      "version": "2.3.24",
+      "resolved": "https://registry.npmjs.org/@heroui/system-rsc/-/system-rsc-2.3.24.tgz",
+      "integrity": "sha512-GEP3hh7j8wE56WdSAIdCcPQOMDdAYk9bSuQpGzXnkYSiSCJKroOyXbRmp9KF2VgpiMXGI0OlO51aj9JWoa+5Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "@heroui/theme": ">=2.4.24",
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/system/node_modules/@heroui/theme": {
+      "version": "2.4.26",
+      "resolved": "https://registry.npmjs.org/@heroui/theme/-/theme-2.4.26.tgz",
+      "integrity": "sha512-TYatChq7YyGDcPJytgOMqQwK72qWYb+vIa7mLmX3Cu9+JzFs2VSHu2QqzdhnOHoK0uJr8giDMy0gvJEDuu31vw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.12",
+        "color": "^4.2.3",
+        "color2k": "^2.0.3",
+        "deepmerge": "4.3.1",
+        "tailwind-merge": "3.4.0",
+        "tailwind-variants": "3.2.2"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=4.0.0"
+      }
+    },
+    "node_modules/@heroui/system/node_modules/tailwindcss": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
+      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@heroui/use-aria-accordion": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-accordion/-/use-aria-accordion-2.2.20.tgz",
+      "integrity": "sha512-HvZhfrsxpCab+m4TrbHWsnA8iLaYdq1G1pjFCswftDRzfioJLmkJ0FMtYDPi792akJO+TWEvPhJibcwVD0bbfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/button": "3.14.5",
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/selection": "3.27.2",
+        "@react-stately/tree": "3.9.6",
+        "@react-types/accordion": "3.0.0-alpha.26",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-button": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-button/-/use-aria-button-2.2.22.tgz",
+      "integrity": "sha512-6Y+fWkf/LKKxw3cd9QCSdLVMrMgKv+0AGCzNCfDiZ5kzQGCX4JQD9eK/495opAHV90yhIWzolwdNwtsyhDploA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/utils": "3.33.1",
+        "@react-types/button": "3.15.1",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-link": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-link/-/use-aria-link-2.2.23.tgz",
+      "integrity": "sha512-jpFj9HNCdt+DENPJyrfoN+AzuaMze9xqo5Y1P3KGoT/2pFDmelFgbXAOC5CHpatYFIn3YEELBGlj84zNXq2gjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/utils": "3.33.1",
+        "@react-types/link": "3.6.7",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-modal-overlay": {
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-modal-overlay/-/use-aria-modal-overlay-2.2.21.tgz",
+      "integrity": "sha512-Qwj5ldLFpfinfGpYUQu92TCpGKzd9Uamhd31ayRvYl6+LwOX124N9ObRYBTXyEiNJ7XFYer3vXQVeaR84xM1Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/use-aria-overlay": "2.0.6",
+        "@react-aria/overlays": "3.31.2",
+        "@react-aria/utils": "3.33.1",
+        "@react-stately/overlays": "3.6.23"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-multiselect": {
+      "version": "2.4.21",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-multiselect/-/use-aria-multiselect-2.4.21.tgz",
+      "integrity": "sha512-f/7YkTfS67OMXXYCO9WTI0Fj9YGPOgdwMIqhaSnFdA2UywA3W71PPeEqpKeuvO6isBW53YOynAPMZXF1NcsuHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/i18n": "3.12.16",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/label": "3.7.25",
+        "@react-aria/listbox": "3.15.3",
+        "@react-aria/menu": "3.21.0",
+        "@react-aria/selection": "3.27.2",
+        "@react-aria/utils": "3.33.1",
+        "@react-stately/form": "3.2.4",
+        "@react-stately/list": "3.13.4",
+        "@react-stately/menu": "3.9.11",
+        "@react-types/button": "3.15.1",
+        "@react-types/overlays": "3.9.4",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-aria-overlay": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@heroui/use-aria-overlay/-/use-aria-overlay-2.0.6.tgz",
+      "integrity": "sha512-7q8oj5DZjr9oGYUB1UTOBnnuAapkBmfATCsdUeNOxQdYb2glJp52sTUslO+ykI9xVOAJSGYAmGuWgY5d+8mD6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/focus": "3.21.5",
+        "@react-aria/interactions": "3.27.1",
+        "@react-aria/overlays": "3.31.2",
+        "@react-types/shared": "3.33.1"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@heroui/use-callback-ref": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@heroui/use-callback-ref/-/use-callback-ref-2.1.8.tgz",
+      "integrity": "sha512-D1JDo9YyFAprYpLID97xxQvf86NvyWLay30BeVVZT9kWmar6O9MbCRc7ACi7Ngko60beonj6+amTWkTm7QuY/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/use-safe-layout-effect": "2.1.8"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-clipboard": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@heroui/use-clipboard/-/use-clipboard-2.1.9.tgz",
+      "integrity": "sha512-lkBq5RpXHiPvk1BXKJG8gMM0f7jRMIGnxAXDjAUzZyXKBuWLoM+XlaUWmZHtmkkjVFMX1L4vzA+vxi9rZbenEQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-data-scroll-overflow": {
+      "version": "2.2.13",
+      "resolved": "https://registry.npmjs.org/@heroui/use-data-scroll-overflow/-/use-data-scroll-overflow-2.2.13.tgz",
+      "integrity": "sha512-zboLXO1pgYdzMUahDcVt5jf+l1jAQ/D9dFqr7AxWLfn6tn7/EgY0f6xIrgWDgJnM0U3hKxVeY13pAeB4AFTqTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.12"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-disclosure": {
+      "version": "2.2.19",
+      "resolved": "https://registry.npmjs.org/@heroui/use-disclosure/-/use-disclosure-2.2.19.tgz",
+      "integrity": "sha512-N3CBikg1cxik2xp1UQkPUBbKPGrvtdsRyAlOnGygliyr5wKpZHLZi0R/g8OxTZVk3zUSCl7HZJT13ddM5TqEvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/use-callback-ref": "2.1.8",
+        "@react-aria/utils": "3.33.1",
+        "@react-stately/utils": "3.11.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-draggable": {
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/@heroui/use-draggable/-/use-draggable-2.1.20.tgz",
+      "integrity": "sha512-yXn3jU3qiUx6aUd2osbDfddpnUTTh2wAVzpNyI+BXl2Z3rkVU9jqiJxZa+BXfsqFX17KrlrxwPPBmLNhSdBKHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/interactions": "3.27.1"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-form-reset": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@heroui/use-form-reset/-/use-form-reset-2.0.1.tgz",
+      "integrity": "sha512-6slKWiLtVfgZnVeHVkM9eXgjwI07u0CUaLt2kQpfKPqTSTGfbHgCYJFduijtThhTdKBhdH6HCmzTcnbVlAxBXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-image": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/@heroui/use-image/-/use-image-2.1.14.tgz",
+      "integrity": "sha512-eCxtKOsM1tszBKYqz8qIJwGIxEAUC7ua+6L9vK8JgG6gOC0jEPFGH7keQuPVprzRtG3DmNt90icowqEjnOHdFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/react-utils": "2.1.14",
+        "@heroui/use-safe-layout-effect": "2.1.8"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-intersection-observer": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/@heroui/use-intersection-observer/-/use-intersection-observer-2.2.14.tgz",
+      "integrity": "sha512-qYJeMk4cTsF+xIckRctazCgWQ4BVOpJu+bhhkB1NrN+MItx19Lcb7ksOqMdN5AiSf85HzDcAEPIQ9w9RBlt5sg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-is-mobile": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/@heroui/use-is-mobile/-/use-is-mobile-2.2.12.tgz",
+      "integrity": "sha512-2UKa4v1xbvFwerWKoMTrg4q9ZfP9MVIVfCl1a7JuKQlXq3jcyV6z1as5bZ41pCsTOT+wUVOFnlr6rzzQwT9ZOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/ssr": "3.9.10"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-is-mounted": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@heroui/use-is-mounted/-/use-is-mounted-2.1.8.tgz",
+      "integrity": "sha512-DO/Th1vD4Uy8KGhd17oGlNA4wtdg91dzga+VMpmt94gSZe1WjsangFwoUBxF2uhlzwensCX9voye3kerP/lskg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-measure": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@heroui/use-measure/-/use-measure-2.1.8.tgz",
+      "integrity": "sha512-GjT9tIgluqYMZWfAX6+FFdRQBqyHeuqUMGzAXMTH9kBXHU0U5C5XU2c8WFORkNDoZIg1h13h1QdV+Vy4LE1dEA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-pagination": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/@heroui/use-pagination/-/use-pagination-2.2.20.tgz",
+      "integrity": "sha512-+ZK+vJgLq7JKLJAnIwfbxe/oF1hANtIiCR6H++q7fOw9pxZZQsntmLEu4kvRhpGZRp5C5T10A1GKIK7/xz1ZdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@heroui/shared-utils": "2.1.12",
+        "@react-aria/i18n": "3.12.16"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-resize": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@heroui/use-resize/-/use-resize-2.1.8.tgz",
+      "integrity": "sha512-htF3DND5GmrSiMGnzRbISeKcH+BqhQ/NcsP9sBTIl7ewvFaWiDhEDiUHdJxflmJGd/c5qZq2nYQM/uluaqIkKA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-safe-layout-effect": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@heroui/use-safe-layout-effect/-/use-safe-layout-effect-2.1.8.tgz",
+      "integrity": "sha512-wbnZxVWCYqk10XRMu0veSOiVsEnLcmGUmJiapqgaz0fF8XcpSScmqjTSoWjHIEWaHjQZ6xr+oscD761D6QJN+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-scroll-position": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@heroui/use-scroll-position/-/use-scroll-position-2.1.8.tgz",
+      "integrity": "sha512-NxanHKObxVfWaPpNRyBR8v7RfokxrzcHyTyQfbgQgAGYGHTMaOGkJGqF8kBzInc3zJi+F0zbX7Nb0QjUgsLNUQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@heroui/use-viewport-size": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@heroui/use-viewport-size/-/use-viewport-size-2.0.1.tgz",
+      "integrity": "sha512-blv8BEB/QdLePLWODPRzRS2eELJ2eyHbdOIADbL0KcfLzOUEg9EiuVk90hcSUDAFqYiJ3YZ5Z0up8sdPcR8Y7g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@internationalized/date": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.5.2.tgz",
-      "integrity": "sha512-vo1yOMUt2hzp63IutEaTUxROdvQg1qlMRsbCvbay2AK2Gai7wIgCyK5weEX3nHkiLgo4qCXHijFNC/ILhlRpOQ==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.0.tgz",
+      "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@internationalized/message": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.2.tgz",
-      "integrity": "sha512-MHAWsZWz8jf6jFPZqpTudcCM361YMtPIRu9CXkYmKjJ/0R3pQRScV5C0zS+Qi50O5UAm8ecKhkXx6mWDDcF6/g==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.8.tgz",
+      "integrity": "sha512-Rwk3j/TlYZhn3HQ6PyXUV0XP9Uv42jqZGNegt0BXlxjE6G3+LwHjbQZAGHhCnCPdaA6Tvd3ma/7QzLlLkJxAWA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
         "intl-messageformat": "^10.1.0"
       }
     },
     "node_modules/@internationalized/number": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.5.1.tgz",
-      "integrity": "sha512-N0fPU/nz15SwR9IbfJ5xaS9Ss/O5h1sVXMZf43vc9mxEG48ovglvvzBjF53aHlq20uoR6c+88CrIXipU/LSzwg==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.5.tgz",
+      "integrity": "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@internationalized/string": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.1.tgz",
-      "integrity": "sha512-vWQOvRIauvFMzOO+h7QrdsJmtN1AXAFVcaLWP9AseRN2o7iHceZ6bIXhBD4teZl8i91A3gxKnWBlGgjCwU6MFQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.7.tgz",
+      "integrity": "sha512-D4OHBjrinH+PFZPvfCXvG28n2LSykWcJ7GIioQL+ok0LON15SdfoUssoHzzOUmVZLbRoREsQXVzA6r8JKsbP6A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.1.tgz",
-      "integrity": "sha512-qsHJle3GU3CmVx7pUoXcghX4sRN+vINkbLdH611T8ZlsP//grzqVW87BSUgOZeSAD4q7ZdZicdwNe/20U2janA=="
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.12.tgz",
+      "integrity": "sha512-pUvdJN1on574wQHjaBfNGDt9Mz5utDSZFsIIQkMzPgNS8ZvT4H2mwOrOIClwsQOb6EGx5M76/CZr6G8i6pSpLg==",
+      "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.1.tgz",
-      "integrity": "sha512-kGjnjcIJehEcd3rT/3NAATJQndAEELk0J9GmGMXHSC75TMnvpOhONcjNHbjtcWE5HUQnIHy5JVkatrnYm1QhVw==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.12.tgz",
+      "integrity": "sha512-RnRjBtH8S8eXCpUNkQ+543DUc7ys8y15VxmFU9HRqlo9BG3CcBUiwNtF8SNoi2xvGCVJq1vl2yYq+3oISBS0Zg==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -204,12 +2242,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.1.tgz",
-      "integrity": "sha512-dAdWndgdQi7BK2WSXrx4lae7mYcOYjbHJUhvOUnJjMNYrmYhxbbvJ2xElZpxNxdfA6zkqagIB9He2tQk+l16ew==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.12.tgz",
+      "integrity": "sha512-nqa9/7iQlboF1EFtNhWxQA0rQstmYRSBGxSM6g3GxvxHxcoeqVXfGNr9stJOme674m2V7r4E3+jEhhGvSQhJRA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -219,12 +2258,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.1.tgz",
-      "integrity": "sha512-2ZctfnyFOGvTkoD6L+DtQtO3BfFz4CapoHnyLTXkOxbZkVRgg3TQBUjTD/xKrO1QWeydeo8AWfZRg8539qNKrg==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.12.tgz",
+      "integrity": "sha512-dCzAjqhDHwmoB2M4eYfVKqXs99QdQxNQVpftvP1eGVppamXh/OkDAwV737Zr0KPXEqRUMN4uCjh6mjO+XtF3Mw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -234,12 +2274,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.1.tgz",
-      "integrity": "sha512-jazZXctiaanemy4r+TPIpFP36t1mMwWCKMsmrTRVChRqE6putyAxZA4PDujx0SnfvZHosjdkx9xIq9BzBB5tWg==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.12.tgz",
+      "integrity": "sha512-+fpGWvQiITgf7PUtbWY1H7qUSnBZsPPLyyq03QuAKpVoTy/QUx1JptEDTQMVvQhvizCEuNLEeghrQUyXQOekuw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -249,12 +2290,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.1.tgz",
-      "integrity": "sha512-VjCHWCjsAzQAAo8lkBOLEIkBZFdfW+Z18qcQ056kL4KpUYc8o59JhLDCBlhg+hINQRgzQ2UPGma2AURGOH0+Qg==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.12.tgz",
+      "integrity": "sha512-jSLvgdRRL/hrFAPqEjJf1fFguC719kmcptjNVDJl26BnJIpjL3KH5h6mzR4mAweociLQaqvt4UyzfbFjgAdDcw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -264,12 +2306,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.1.tgz",
-      "integrity": "sha512-7HZKYKvAp4nAHiHIbY04finRqjeYvkITOGOurP1aLMexIFG/1+oCnqhGogBdc4lao/lkMW1c+AkwWSzSlLasqw==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.12.tgz",
+      "integrity": "sha512-/uaF0WfmYqQgLfPmN6BvULwxY0dufI2mlN2JbOKqqceZh1G4hjREyi7pg03zjfyS6eqNemHAZPSoP84x17vo6w==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -279,27 +2322,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.1.tgz",
-      "integrity": "sha512-YGHklaJ/Cj/F0Xd8jxgj2p8po4JTCi6H7Z3Yics3xJhm9CPIqtl8erlpK1CLv+HInDqEWfXilqatF8YsLxxA2Q==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.12.tgz",
+      "integrity": "sha512-xhsL1OvQSfGmlL5RbOmU+FV120urrgFpYLq+6U8C6KIym32gZT6XF/SDE92jKzzlPWskkbjOKCpqk5m4i8PEfg==",
       "cpu": [
         "arm64"
       ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.1.tgz",
-      "integrity": "sha512-o+ISKOlvU/L43ZhtAAfCjwIfcwuZstiHVXq/BDsZwGqQE0h/81td95MPHliWCnFoikzWcYqh+hz54ZB2FIT8RA==",
-      "cpu": [
-        "ia32"
-      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -309,12 +2338,13 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.1.tgz",
-      "integrity": "sha512-GmRoTiLcvCLifujlisknv4zu9/C4i9r0ktsA8E51EMqJL4bD4CpO7lDYr7SrUxCR0tS4RVcrqKmCak24T0ohaw==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.12.tgz",
+      "integrity": "sha512-Z1Dh6lhFkxvBDH1FoW6OU/L6prYwPSlwjLiZkExIAh8fbP6iI/M7iGTQAJPYJ9YFlWobCZ1PHbchFhFYb2ADkw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -323,1248 +2353,11 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@nextui-org/accordion": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/@nextui-org/accordion/-/accordion-2.0.28.tgz",
-      "integrity": "sha512-WzD7sscL+4K0TFyUutTn1AhU0wcS68TqNCTNv7KgON6ODdwieydilMxAyXvwo3RgXeWG+8BbdxJC/6W+/iLBTg==",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.0.15",
-        "@nextui-org/divider": "2.0.25",
-        "@nextui-org/framer-transitions": "2.0.15",
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-icons": "2.0.6",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-aria-accordion": "2.0.2",
-        "@nextui-org/use-aria-press": "2.0.1",
-        "@react-aria/button": "^3.8.4",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/tree": "^3.7.3",
-        "@react-types/accordion": "3.0.0-alpha.17",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "framer-motion": ">=4.0.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/aria-utils": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@nextui-org/aria-utils/-/aria-utils-2.0.15.tgz",
-      "integrity": "sha512-4M4jeJ/ghGaia9064yS+mEZ3sFPH80onmjNGWJZkkZDmUV4R88lNkqe/XYBK1tbxfl4Kxa8jc/ALsZkUkkvR5w==",
-      "dependencies": {
-        "@nextui-org/react-rsc-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/system": "2.0.15",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/collections": "^3.10.2",
-        "@react-types/overlays": "^3.8.3",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/autocomplete": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@nextui-org/autocomplete/-/autocomplete-2.0.10.tgz",
-      "integrity": "sha512-nQr8VC5RtpjnPef1qXgjNxRAw8JbN6q5qIFtsHWOCzvvn5jGAtdxkAkNE4C7DTvlMWZkIlEuR4DyAmFfY8CChQ==",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.0.15",
-        "@nextui-org/button": "2.0.27",
-        "@nextui-org/input": "2.1.17",
-        "@nextui-org/listbox": "2.1.16",
-        "@nextui-org/popover": "2.1.15",
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/scroll-shadow": "2.1.13",
-        "@nextui-org/shared-icons": "2.0.6",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/spinner": "2.0.25",
-        "@nextui-org/use-aria-button": "2.0.6",
-        "@react-aria/combobox": "^3.7.1",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/i18n": "^3.8.4",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-aria/visually-hidden": "^3.8.6",
-        "@react-stately/combobox": "^3.7.1",
-        "@react-types/combobox": "^3.8.1",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "framer-motion": ">=4.0.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/avatar": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@nextui-org/avatar/-/avatar-2.0.24.tgz",
-      "integrity": "sha512-3QUn8v61iNvAYogUbEDVnhDjBK6WBxxFYLp95a0H52zN0p2LHXe+UNwdGZYFo5QNWx6CHGH3vh2AHlLLy3WFSQ==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-image": "2.0.4",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/utils": "^3.21.1"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/badge": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@nextui-org/badge/-/badge-2.0.24.tgz",
-      "integrity": "sha512-FA3XgqEbyKWepMXqMZg7D+1IRf7flrb2LzFvTbkmsbvWQ4yYz1LqJXZ/HDmoCydvh2pOnc+1zPK3BpB7vGrrwA==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/system-rsc": "2.0.11"
-      },
-      "peerDependencies": {
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/breadcrumbs": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nextui-org/breadcrumbs/-/breadcrumbs-2.0.4.tgz",
-      "integrity": "sha512-SAE0+QRgA7vxUHPL65TKz3MRj7u2mbSwk8Eifkwo6hPcF0d34zv2QDupTGyphIjoGCSrQHFIq/CPAkXyaOXZxw==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-icons": "2.0.6",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@react-aria/breadcrumbs": "^3.5.7",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/utils": "^3.21.1",
-        "@react-types/breadcrumbs": "^3.7.1",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/button": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.0.27.tgz",
-      "integrity": "sha512-oErzUr9KtE/qjUx4dSbalphxURssxGf9tv0mW++ZMkmVX1E6i887FwZb9xAVm9oBwYwR6+xpJaqjQLmt8aN/rQ==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/ripple": "2.0.24",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/spinner": "2.0.25",
-        "@nextui-org/use-aria-button": "2.0.6",
-        "@react-aria/button": "^3.8.4",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-types/button": "^3.9.0",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "framer-motion": ">=4.0.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/card": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@nextui-org/card/-/card-2.0.24.tgz",
-      "integrity": "sha512-16uAS0i6+EO+u8aqtmaCXatjovsyuTq51JwCLBlB67OldfgXoYcYl3GaE2VoZdEwxVu1G/qypDfXv29k46nZuA==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/ripple": "2.0.24",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-aria-button": "2.0.6",
-        "@react-aria/button": "^3.8.4",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "framer-motion": ">=4.0.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/checkbox": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/@nextui-org/checkbox/-/checkbox-2.0.25.tgz",
-      "integrity": "sha512-X6WkwPbZlDvioEcXF6HhKH21wD6OK+3+FSroKkzMPQLJrj2KYUIYGbiuw9rT9aCtdjbT+6HUCv+FA8/cBQr7cA==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-aria-press": "2.0.1",
-        "@react-aria/checkbox": "^3.11.2",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-aria/visually-hidden": "^3.8.6",
-        "@react-stately/checkbox": "^3.5.1",
-        "@react-stately/toggle": "^3.6.3",
-        "@react-types/checkbox": "^3.5.2",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/chip": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/@nextui-org/chip/-/chip-2.0.25.tgz",
-      "integrity": "sha512-hfVSaq5JWzGn97s3K2Ac/xOopHWelaUW3eus0O0wns/6+NCI0QUjgwNt2bAQSNvnE6vjvYLJTqGG/jFHyFJjOg==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-icons": "2.0.6",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-aria-press": "2.0.1",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-types/checkbox": "^3.5.2"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/code": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@nextui-org/code/-/code-2.0.24.tgz",
-      "integrity": "sha512-Kw/uOQtdytRWY99zMQuGHqMAAGXWBAxHlyMMge1OCckpadCDfX6plPjqoS18SGM0orJ4fox+a1FM8VhnRQ2kQw==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/system-rsc": "2.0.11"
-      },
-      "peerDependencies": {
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/divider": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/@nextui-org/divider/-/divider-2.0.25.tgz",
-      "integrity": "sha512-yEvHqYlhNBwmF68pfjJKdzC8gVQtL+txxD5COBGF9uFyfxA5hVw2D6GmYgOH514bxrFBuWOLcQX6gyljgcN3bA==",
-      "dependencies": {
-        "@nextui-org/react-rsc-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/system-rsc": "2.0.11",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/dropdown": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/@nextui-org/dropdown/-/dropdown-2.1.17.tgz",
-      "integrity": "sha512-Hxmz1Yf/LjjOLqWRF49Q5ZYJtae6ydDEk1mv8oMKNmSWHi92lrgmHlwkGvR3mjczbRuF+WkXHLEhVZH6/tZQ7A==",
-      "dependencies": {
-        "@nextui-org/menu": "2.0.17",
-        "@nextui-org/popover": "2.1.15",
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/menu": "^3.11.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/menu": "^3.5.6",
-        "@react-types/menu": "^3.9.5"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "framer-motion": ">=4.0.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/framer-transitions": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@nextui-org/framer-transitions/-/framer-transitions-2.0.15.tgz",
-      "integrity": "sha512-UlWMCAFdrq8wKrYFGwc+O4kFhKCkL4L9ZadBkP0PqjmfyAC2gA3ygRbNqtKhFMWeKbBAiC8qQ9aTBEA/+0r/EA==",
-      "dependencies": {
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/system": "2.0.15"
-      },
-      "peerDependencies": {
-        "framer-motion": ">=4.0.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/image": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@nextui-org/image/-/image-2.0.24.tgz",
-      "integrity": "sha512-bps5D5ki7PoLldb8wcJEf6C4EUFZm3PocLytNaGa7dNxFfaCOD78So+kq+K+0IRusK3yn94K8r31qMvpI3Gg2Q==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-image": "2.0.4"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/input": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/@nextui-org/input/-/input-2.1.17.tgz",
-      "integrity": "sha512-3FW3NDDbQOa5IlUCpO2Ma/XEjGnx4TQLM8MvMbskc+GNbZ0mtzfV0hCeQkqxxJ2lP4Mkp4QhwGRRkRrDu1G0Wg==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-icons": "2.0.6",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/textfield": "^3.12.2",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/utils": "^3.8.0",
-        "@react-types/shared": "^3.21.0",
-        "@react-types/textfield": "^3.8.1",
-        "react-textarea-autosize": "^8.5.2"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/kbd": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/@nextui-org/kbd/-/kbd-2.0.25.tgz",
-      "integrity": "sha512-cYwbEjp/+/tjtOdmiRy2UHjfBhP3bqd5e+JFTa5sY1HotckUZrCintATyBcg9bPa3iSPUI44M6Cb9e0oAUUeMA==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/system-rsc": "2.0.11",
-        "@react-aria/utils": "^3.21.1"
-      },
-      "peerDependencies": {
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/link": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/@nextui-org/link/-/link-2.0.26.tgz",
-      "integrity": "sha512-X8zX3U5MWfiStOCd45oIZ2YKZG0GoUio6PcMFYjpOPsEG7wV58CuhUSxpyx3QTF8JavVSO/p/cl4Pc9pukVDUg==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-icons": "2.0.6",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-aria-link": "2.0.15",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/link": "^3.6.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-types/link": "^3.5.1"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/listbox": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@nextui-org/listbox/-/listbox-2.1.16.tgz",
-      "integrity": "sha512-5PmUCoHFgAr+1nAU3IlqPFTgyHo7zsTcNeja4wcErD/KseCF2h7Uk5OqUX5hQDN9B9fZuGjPrkG4yoK/6pqcUQ==",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.0.15",
-        "@nextui-org/divider": "2.0.25",
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-aria-press": "2.0.1",
-        "@nextui-org/use-is-mobile": "2.0.6",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/listbox": "^3.11.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/list": "^3.10.0",
-        "@react-types/menu": "^3.9.5",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/menu": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@nextui-org/menu/-/menu-2.0.17.tgz",
-      "integrity": "sha512-qr/BPDbBvg5tpAZZLkLx8eNnvYwJYM3Q72fmRYbzwmG3upNtdjln0QYxSwPXUz7RYqTKEFWc9JPxq2pgPM15Wg==",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.0.15",
-        "@nextui-org/divider": "2.0.25",
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-aria-press": "2.0.1",
-        "@nextui-org/use-is-mobile": "2.0.6",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/menu": "^3.11.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/menu": "^3.5.6",
-        "@react-stately/tree": "^3.7.3",
-        "@react-types/menu": "^3.9.5",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/modal": {
-      "version": "2.0.29",
-      "resolved": "https://registry.npmjs.org/@nextui-org/modal/-/modal-2.0.29.tgz",
-      "integrity": "sha512-C/pvw0fAPWKbfMoGfIVZWhMRbe+DRGEg7GqPVY7EmW4FSSIK7Sfdn6Jxm+sSv+a7xHpDr86nirFbvN3S4jCaHw==",
-      "dependencies": {
-        "@nextui-org/framer-transitions": "2.0.15",
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-icons": "2.0.6",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-aria-button": "2.0.6",
-        "@nextui-org/use-aria-modal-overlay": "2.0.6",
-        "@nextui-org/use-disclosure": "2.0.6",
-        "@react-aria/dialog": "^3.5.7",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/overlays": "^3.18.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/overlays": "^3.6.3",
-        "@react-types/overlays": "^3.8.3",
-        "react-remove-scroll": "^2.5.6"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "framer-motion": ">=4.0.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/navbar": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/@nextui-org/navbar/-/navbar-2.0.27.tgz",
-      "integrity": "sha512-iP4Pn4ItQkAW1nbu1Jmrh5l9pMVG43lDxq9rbx6DbLjLnnZOOrE6fURb8uN5NVy3ooV5dF02zKAoxlkE5fN/xw==",
-      "dependencies": {
-        "@nextui-org/framer-transitions": "2.0.15",
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-aria-toggle-button": "2.0.6",
-        "@nextui-org/use-scroll-position": "2.0.4",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/overlays": "^3.18.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/toggle": "^3.6.3",
-        "@react-stately/utils": "^3.8.0",
-        "react-remove-scroll": "^2.5.6"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "framer-motion": ">=4.0.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/pagination": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/@nextui-org/pagination/-/pagination-2.0.27.tgz",
-      "integrity": "sha512-v1tSsb0Q863/gKVUxuN7FcE1TZWuvcbWZOrWjKe0/llRgfZ23/4KD1AmFyYuKo5RDFt+i1JWSfzAu08j0Hzzqg==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-icons": "2.0.6",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-aria-press": "2.0.1",
-        "@nextui-org/use-pagination": "2.0.5",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/i18n": "^3.8.4",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/utils": "^3.21.1",
-        "scroll-into-view-if-needed": "3.0.10"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/popover": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/@nextui-org/popover/-/popover-2.1.15.tgz",
-      "integrity": "sha512-FQ66y49sQvXvyDrEsEFAC0qfpl2X+5ZPGaVXdNd3Cjox/jxAxp93cSUkk0iOfYvdsbO5zVFjuM0L3Dqn4hsHMw==",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.0.15",
-        "@nextui-org/button": "2.0.27",
-        "@nextui-org/framer-transitions": "2.0.15",
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-aria-button": "2.0.6",
-        "@nextui-org/use-safe-layout-effect": "2.0.4",
-        "@react-aria/dialog": "^3.5.7",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/overlays": "^3.18.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/overlays": "^3.6.3",
-        "@react-types/button": "^3.9.0",
-        "@react-types/overlays": "^3.8.3",
-        "react-remove-scroll": "^2.5.6"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "framer-motion": ">=4.0.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/progress": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/@nextui-org/progress/-/progress-2.0.25.tgz",
-      "integrity": "sha512-EFVxwT0CXq+2scPLhKKRHkWb6xNa6Vjx+HdgSg3l4lgAxAUryvdfksjW8vjxn6x4I2rGbdzAYPEu27p2KaK7jg==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-is-mounted": "2.0.4",
-        "@react-aria/i18n": "^3.8.4",
-        "@react-aria/progress": "^3.4.7",
-        "@react-aria/utils": "^3.21.1",
-        "@react-types/progress": "^3.5.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/radio": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/@nextui-org/radio/-/radio-2.0.25.tgz",
-      "integrity": "sha512-vRX0ppM5Tlzu0HoqTG6LdmQnMjk8RRl66BH1+QaosvZRXA1iIdA3BduqQYqn5ZZHBBlJ2u9QzaD3lTAlWIHvNg==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-aria-press": "2.0.1",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/radio": "^3.8.2",
-        "@react-aria/utils": "^3.21.1",
-        "@react-aria/visually-hidden": "^3.8.6",
-        "@react-stately/radio": "^3.9.1",
-        "@react-types/radio": "^3.5.2",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/react": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/@nextui-org/react/-/react-2.2.10.tgz",
-      "integrity": "sha512-YJhUIeLnO/FGDbZgfeWEz32RBrH2YFA1qsJQtMF7mza8rjspX/CkankvI7xs1o6sW/TYLSTq7sOF9RGMxLTIAA==",
-      "dependencies": {
-        "@nextui-org/accordion": "2.0.28",
-        "@nextui-org/autocomplete": "2.0.10",
-        "@nextui-org/avatar": "2.0.24",
-        "@nextui-org/badge": "2.0.24",
-        "@nextui-org/breadcrumbs": "2.0.4",
-        "@nextui-org/button": "2.0.27",
-        "@nextui-org/card": "2.0.24",
-        "@nextui-org/checkbox": "2.0.25",
-        "@nextui-org/chip": "2.0.25",
-        "@nextui-org/code": "2.0.24",
-        "@nextui-org/divider": "2.0.25",
-        "@nextui-org/dropdown": "2.1.17",
-        "@nextui-org/image": "2.0.24",
-        "@nextui-org/input": "2.1.17",
-        "@nextui-org/kbd": "2.0.25",
-        "@nextui-org/link": "2.0.26",
-        "@nextui-org/listbox": "2.1.16",
-        "@nextui-org/menu": "2.0.17",
-        "@nextui-org/modal": "2.0.29",
-        "@nextui-org/navbar": "2.0.27",
-        "@nextui-org/pagination": "2.0.27",
-        "@nextui-org/popover": "2.1.15",
-        "@nextui-org/progress": "2.0.25",
-        "@nextui-org/radio": "2.0.25",
-        "@nextui-org/ripple": "2.0.24",
-        "@nextui-org/scroll-shadow": "2.1.13",
-        "@nextui-org/select": "2.1.21",
-        "@nextui-org/skeleton": "2.0.24",
-        "@nextui-org/slider": "2.2.6",
-        "@nextui-org/snippet": "2.0.31",
-        "@nextui-org/spacer": "2.0.24",
-        "@nextui-org/spinner": "2.0.25",
-        "@nextui-org/switch": "2.0.25",
-        "@nextui-org/system": "2.0.15",
-        "@nextui-org/table": "2.0.28",
-        "@nextui-org/tabs": "2.0.26",
-        "@nextui-org/theme": "2.1.18",
-        "@nextui-org/tooltip": "2.0.30",
-        "@nextui-org/user": "2.0.25",
-        "@react-aria/visually-hidden": "^3.8.6"
-      },
-      "peerDependencies": {
-        "framer-motion": ">=4.0.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/react-rsc-utils": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@nextui-org/react-rsc-utils/-/react-rsc-utils-2.0.10.tgz",
-      "integrity": "sha512-LNePDEThUF9PAbJW4T8k7EgSfqwlvGku5fIqJ1IA9+OpVy5LqhrUQehjvgXe63N1RupC7Pt+XvaaxkGu9U2FiQ=="
-    },
-    "node_modules/@nextui-org/react-utils": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@nextui-org/react-utils/-/react-utils-2.0.10.tgz",
-      "integrity": "sha512-bcA+k7ZdcgcK+r/8nrCtbdgHo0SD6jicbazWIokknFwjb97JQ7ooaMwxnLt5E5sswCAv0XeLwybOmrgm7JA5TA==",
-      "dependencies": {
-        "@nextui-org/react-rsc-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/ripple": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@nextui-org/ripple/-/ripple-2.0.24.tgz",
-      "integrity": "sha512-PCvAk9ErhmPX46VRmhsg8yMxw3Qd9LY7BDkRRfIF8KftgRDyOpG2vV8DxvSOxQu1/aqBWkkHNUuEjM/EvSEung==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "framer-motion": ">=4.0.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/scroll-shadow": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/@nextui-org/scroll-shadow/-/scroll-shadow-2.1.13.tgz",
-      "integrity": "sha512-hFoVGplGMWuE+KXRz9gtKRq3e0YYkxutrqjDD0BiDHk4WkiyOrTnNuE6wnJTnd6Hd+kavLPBDu2+yGauDb7/Qg==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-data-scroll-overflow": "2.1.3"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/select": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/@nextui-org/select/-/select-2.1.21.tgz",
-      "integrity": "sha512-BVfmxIsZTL6dBiZ1Q5RbAnqiNpVnaJgWi0M1QMV448FHMaDHLTWtNOJPMD0QyxHRNPfDgFrqEAq6a1+pA26ckQ==",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.0.15",
-        "@nextui-org/listbox": "2.1.16",
-        "@nextui-org/popover": "2.1.15",
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/scroll-shadow": "2.1.13",
-        "@nextui-org/shared-icons": "2.0.6",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/spinner": "2.0.25",
-        "@nextui-org/use-aria-button": "2.0.6",
-        "@nextui-org/use-aria-multiselect": "2.1.4",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-aria/visually-hidden": "^3.8.6",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "framer-motion": ">=4.0.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/shared-icons": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/shared-icons/-/shared-icons-2.0.6.tgz",
-      "integrity": "sha512-Mw5utPJAclFaeKAZowznEgabI5gdhXrW0iMaMA18Y4zcZRTidAc0WFeGYUlX876NxYLPc1Zk4bZUhQvMe+7uWg==",
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/shared-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nextui-org/shared-utils/-/shared-utils-2.0.4.tgz",
-      "integrity": "sha512-Ms7A6UCvo/SZt/9Nmb7cZwHe9fZFw+EPsieTnC1vtpvDNCasxrTB0hj9VWFoYfWOaCzzqxl1AL9maIz/gMvckQ==",
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/skeleton": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@nextui-org/skeleton/-/skeleton-2.0.24.tgz",
-      "integrity": "sha512-bsb+lYugSfQV3RHrEHLbHhkkeslaxybnnT4z485Y/GBYTENOiHIOnWFWntfxCbjZ6vCewGlfgnphj6zeqlk20g==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/system-rsc": "2.0.11"
-      },
-      "peerDependencies": {
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/slider": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/slider/-/slider-2.2.6.tgz",
-      "integrity": "sha512-adCjQ8k4bUwWcvmOJUki3+UVsCz4ms+qLG4jnY2wClPdQAwISMbZzQsuv3km+1HIZE5Ja7jzeeT/dMd8l3n+bg==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/tooltip": "2.0.30",
-        "@nextui-org/use-aria-press": "2.0.1",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/i18n": "^3.8.4",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/slider": "^3.7.2",
-        "@react-aria/utils": "^3.21.1",
-        "@react-aria/visually-hidden": "^3.8.6",
-        "@react-stately/slider": "^3.4.4"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/snippet": {
-      "version": "2.0.31",
-      "resolved": "https://registry.npmjs.org/@nextui-org/snippet/-/snippet-2.0.31.tgz",
-      "integrity": "sha512-WooH5cqlHoa6SqUhzseKY7g1ah8kzSv382u95Or9kIgSirEZCrjygup3nFeKTMAe01NZoAz3OOYO7XNFWJ57vA==",
-      "dependencies": {
-        "@nextui-org/button": "2.0.27",
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-icons": "2.0.6",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/tooltip": "2.0.30",
-        "@nextui-org/use-clipboard": "2.0.4",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/utils": "^3.21.1"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "framer-motion": ">=4.0.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/spacer": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@nextui-org/spacer/-/spacer-2.0.24.tgz",
-      "integrity": "sha512-bLnhPRnoyHQXhLneHjbRqZNxJWMFOBYOZkuX83uy59/FFUY07BcoNsb2s80tN3GoVxsaZ2jB6NxxVbaCJwoPog==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/system-rsc": "2.0.11"
-      },
-      "peerDependencies": {
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/spinner": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/@nextui-org/spinner/-/spinner-2.0.25.tgz",
-      "integrity": "sha512-s2iqaB71sanRxglJtG4UZF+Rz/W6UxnYegbkhnkkljH20vhOcrhwm5jKGStq8jkata8UZ0ajS67H8KY8lHV8nw==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/system-rsc": "2.0.11"
-      },
-      "peerDependencies": {
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/switch": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/@nextui-org/switch/-/switch-2.0.25.tgz",
-      "integrity": "sha512-U7g68eReMSkgG0bBOSdzRLK+npv422YK6WYHpYOSkEBDqGwQ7LCeMRQreT/KxN0QFxIKmafebdLHAbuKc/X+5Q==",
-      "dependencies": {
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-aria-press": "2.0.1",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/switch": "^3.5.6",
-        "@react-aria/utils": "^3.21.1",
-        "@react-aria/visually-hidden": "^3.8.6",
-        "@react-stately/toggle": "^3.6.3",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/system": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.0.15.tgz",
-      "integrity": "sha512-WFDq+Rx6D+gmK1YGEG2RBARPK9EOYonQDt5Tq2tUchzOOqj3kXXcM5Z0F3fudM59eIncLa/tX/ApJSTLry+hsw==",
-      "dependencies": {
-        "@nextui-org/system-rsc": "2.0.11",
-        "@react-aria/i18n": "^3.8.4",
-        "@react-aria/overlays": "^3.18.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/utils": "^3.8.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/system-rsc": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@nextui-org/system-rsc/-/system-rsc-2.0.11.tgz",
-      "integrity": "sha512-1QqZ+GM7Ii0rsfSHXS6BBjzKOoLIWwb72nm4h4WgjlMXbRKLZcCQasRHVe5HMSBMvN0JUo7qyGExchfDFl/Ubw==",
-      "dependencies": {
-        "clsx": "^1.2.1"
-      },
-      "peerDependencies": {
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "tailwind-variants": ">=0.1.13"
-      }
-    },
-    "node_modules/@nextui-org/table": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/@nextui-org/table/-/table-2.0.28.tgz",
-      "integrity": "sha512-qH/7jdV5+tiMDDvBfMrUZN4jamds0FsL5Ak+ighoKIUYRFTSXOroi+63ZzzAh/mZAsUALCPPcfbXt4r4aBFDzg==",
-      "dependencies": {
-        "@nextui-org/checkbox": "2.0.25",
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-icons": "2.0.6",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/spacer": "2.0.24",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/table": "^3.13.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-aria/visually-hidden": "^3.8.6",
-        "@react-stately/table": "^3.11.2",
-        "@react-stately/virtualizer": "^3.6.4",
-        "@react-types/grid": "^3.2.2",
-        "@react-types/table": "^3.9.0"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/tabs": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/@nextui-org/tabs/-/tabs-2.0.26.tgz",
-      "integrity": "sha512-GjERgBYUAY1KD4GqNVy0cRi6GyQnf62q0ddcN4je3sEM6rsq3PygEXhkN5pxxFPacoYM/UE6rBswHSKlbjJjgw==",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.0.15",
-        "@nextui-org/framer-transitions": "2.0.15",
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-is-mounted": "2.0.4",
-        "@nextui-org/use-update-effect": "2.0.4",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/tabs": "^3.8.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/tabs": "^3.6.1",
-        "@react-types/shared": "^3.21.0",
-        "@react-types/tabs": "^3.3.3",
-        "scroll-into-view-if-needed": "3.0.10"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "framer-motion": ">=4.0.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/theme": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/@nextui-org/theme/-/theme-2.1.18.tgz",
-      "integrity": "sha512-2ptDh350lVD0yejZTpGv4fkeoGKB8+B/Coblzpjijfofn/t6MQIRIRRLp04wCCa/IbeevjS2wyadWpMDtVh3CQ==",
-      "dependencies": {
-        "color": "^4.2.3",
-        "color2k": "^2.0.2",
-        "deepmerge": "4.3.1",
-        "flat": "^5.0.2",
-        "lodash.foreach": "^4.5.0",
-        "lodash.get": "^4.4.2",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.mapkeys": "^4.6.0",
-        "lodash.omit": "^4.5.0",
-        "tailwind-variants": "^0.1.18"
-      },
-      "peerDependencies": {
-        "tailwindcss": "*"
-      }
-    },
-    "node_modules/@nextui-org/theme/node_modules/tailwind-merge": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.14.0.tgz",
-      "integrity": "sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/dcastil"
-      }
-    },
-    "node_modules/@nextui-org/theme/node_modules/tailwind-variants": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-0.1.20.tgz",
-      "integrity": "sha512-AMh7x313t/V+eTySKB0Dal08RHY7ggYK0MSn/ad8wKWOrDUIzyiWNayRUm2PIJ4VRkvRnfNuyRuKbLV3EN+ewQ==",
-      "dependencies": {
-        "tailwind-merge": "^1.14.0"
-      },
-      "engines": {
-        "node": ">=16.x",
-        "pnpm": ">=7.x"
-      },
-      "peerDependencies": {
-        "tailwindcss": "*"
-      }
-    },
-    "node_modules/@nextui-org/tooltip": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/@nextui-org/tooltip/-/tooltip-2.0.30.tgz",
-      "integrity": "sha512-V3N9o/oNU1Y11etiilrlqt5dF4/o9eJSttgN2CPo8eRAPc96+sRpdGPGX3XcLJZNFRcNx8BkD/bcEUcrDdjmRA==",
-      "dependencies": {
-        "@nextui-org/aria-utils": "2.0.15",
-        "@nextui-org/framer-transitions": "2.0.15",
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@nextui-org/use-safe-layout-effect": "2.0.4",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/overlays": "^3.18.1",
-        "@react-aria/tooltip": "^3.6.4",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/tooltip": "^3.4.5",
-        "@react-types/overlays": "^3.8.3",
-        "@react-types/tooltip": "^3.4.5"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "framer-motion": ">=4.0.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-accordion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-accordion/-/use-aria-accordion-2.0.2.tgz",
-      "integrity": "sha512-ebYr4CdvWifuTM/yyhQLKCa7aUqbVrWyR0SB6VNCGDID/kvRUW52puWnY9k24xdwY0cKbW3JRciKtQkrokRQwg==",
-      "dependencies": {
-        "@react-aria/button": "^3.8.4",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/selection": "^3.17.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/tree": "^3.7.3",
-        "@react-types/accordion": "3.0.0-alpha.17",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-button": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-button/-/use-aria-button-2.0.6.tgz",
-      "integrity": "sha512-38DZ3FK/oPZ3sppfM5EtgJ4DITOajNwSKkAMePBmuSZl+bsW7peP8g5JNd9uPOEz3edCOppT60AQSICsYiH3cg==",
-      "dependencies": {
-        "@nextui-org/use-aria-press": "2.0.1",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-types/button": "^3.9.0",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-link": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-link/-/use-aria-link-2.0.15.tgz",
-      "integrity": "sha512-znzOeTZ10o3O5F2nihi8BR8rAhRHgrRWcEBovV7OqJeFzvTQwsHl9/xy45zBfwJQksBtfcBfQf+GEHXeDwfigA==",
-      "dependencies": {
-        "@nextui-org/use-aria-press": "2.0.1",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-types/link": "^3.5.1",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-modal-overlay": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-modal-overlay/-/use-aria-modal-overlay-2.0.6.tgz",
-      "integrity": "sha512-JfhXvH2RObWpHeLmxdIBDPF2SDzV4SqBvEh01yRvg/EuZ3HDRfCnTDh+5HD0ziUVdk/kWuy/hZLX59sMX7QHWA==",
-      "dependencies": {
-        "@react-aria/overlays": "^3.18.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/overlays": "^3.6.3",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-multiselect": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-multiselect/-/use-aria-multiselect-2.1.4.tgz",
-      "integrity": "sha512-F95sF4eY5TLkom5tIMb+eoT4i0Cc4qygnQRqIosg8OryDbH62/MV4x88GjQsgDCY8dNeWCNVodHXxaWmVSAgyQ==",
-      "dependencies": {
-        "@react-aria/i18n": "^3.8.4",
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/label": "^3.7.2",
-        "@react-aria/listbox": "^3.11.1",
-        "@react-aria/menu": "^3.11.1",
-        "@react-aria/selection": "^3.17.1",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/list": "^3.10.0",
-        "@react-stately/menu": "^3.5.6",
-        "@react-types/button": "^3.9.0",
-        "@react-types/overlays": "^3.8.3",
-        "@react-types/select": "^3.8.4",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-press": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-press/-/use-aria-press-2.0.1.tgz",
-      "integrity": "sha512-T3MjHH5TU9qnkf872GmhcfQK16ITMmMW9zir6xsSsz0w6ay9Y0XTSPrI2zRL6ociFyfJjP840XCLtSx6VBfEBQ==",
-      "dependencies": {
-        "@react-aria/interactions": "^3.19.1",
-        "@react-aria/ssr": "^3.8.0",
-        "@react-aria/utils": "^3.21.1",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-aria-toggle-button": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-toggle-button/-/use-aria-toggle-button-2.0.6.tgz",
-      "integrity": "sha512-6Sjp7a0HQjmboLKNZu9AtZmyHz8+vhqcDwJDYTZjrrna0udxEXG+6C14YZzQxoJcvuaMimr5E8Aq0AxyRAr0MQ==",
-      "dependencies": {
-        "@nextui-org/use-aria-button": "2.0.6",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/toggle": "^3.6.3",
-        "@react-types/button": "^3.9.0",
-        "@react-types/shared": "^3.21.0"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-callback-ref": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-callback-ref/-/use-callback-ref-2.0.4.tgz",
-      "integrity": "sha512-GF50SzOFU/R0gQT1TmjbEUiS8CQ87qiV5Rp/TD5pqys1xprVgGLUUNQzlh+YDS2JHNu5FGlZc4sJKhtf2xF5aw==",
-      "dependencies": {
-        "@nextui-org/use-safe-layout-effect": "2.0.4"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-clipboard": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-clipboard/-/use-clipboard-2.0.4.tgz",
-      "integrity": "sha512-rMcaX0QsolOJ1BQbp1T/FVsSPn2m0Ss4Z+bbdS7eM6EFKtJdVJWlpbrST0/kR2UcW1KWeK27NYmtNPF5+hgZMA==",
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-data-scroll-overflow": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-data-scroll-overflow/-/use-data-scroll-overflow-2.1.3.tgz",
-      "integrity": "sha512-f4rDr4MHGQTyqTd6L4MpKAcKfPDiVeWfYXXXX6gdN8UVTk+PzW675Fe+l7ATBgmaVTn1AEPJwW9dDUJcDpn21g==",
-      "dependencies": {
-        "@nextui-org/shared-utils": "2.0.4"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-disclosure": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-disclosure/-/use-disclosure-2.0.6.tgz",
-      "integrity": "sha512-pazzLsAGKjUD4cMVySTivItmIgpsfIf4baP/02K0Xc8tbFAH4K1n7cUnEEjs+MTXy1Bprvz3pfAHDGZRDI1yYg==",
-      "dependencies": {
-        "@nextui-org/use-callback-ref": "2.0.4",
-        "@react-aria/utils": "^3.21.1",
-        "@react-stately/utils": "^3.8.0"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-image": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-image/-/use-image-2.0.4.tgz",
-      "integrity": "sha512-tomOkrhlhTA45qA/MLh1YmiWVGgJ2KeM0qBSLP1ikVcppc/e9UtkIJjHIGdNCnHZTjoPEh53HzyJeUMlYUM9uw==",
-      "dependencies": {
-        "@nextui-org/use-safe-layout-effect": "2.0.4"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-is-mobile": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-is-mobile/-/use-is-mobile-2.0.6.tgz",
-      "integrity": "sha512-HeglWUoq6Ln8P5n6s1SZvBRatLYMKsiXQM7Mk2l+6jFByzZh3VWtZ05xmuX8te/1rGmeUxjeXtW6x+F7/f/JoA==",
-      "dependencies": {
-        "@react-aria/ssr": "^3.8.0"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-is-mounted": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-is-mounted/-/use-is-mounted-2.0.4.tgz",
-      "integrity": "sha512-NSQwQjg8+k02GVov9cDwtAdop1Cr90eDgB0MAdvu7QCMgfBZjy88IdQnx3Yo7bG4wP45xC0vLjqDBanaK+11hw==",
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-pagination": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-pagination/-/use-pagination-2.0.5.tgz",
-      "integrity": "sha512-wH0sC85XeTPPE4zRq0ycAVB+SpmPEiSmTEGxpBG2sqiJlsrNfEeXvTKf73INXM4IWfP53ONAQ7Nd1T7EVuYSkw==",
-      "dependencies": {
-        "@nextui-org/shared-utils": "2.0.4",
-        "@react-aria/i18n": "^3.8.4"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-safe-layout-effect": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-safe-layout-effect/-/use-safe-layout-effect-2.0.4.tgz",
-      "integrity": "sha512-K7ppEhTfzdVOzbgKaNFEBi4HwRfQ8j+kRBQqsU5yo8bSM+5uv8OUy/mjpEf4i02PUDIBmsgJC4En9S537DXrwg==",
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-scroll-position": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-scroll-position/-/use-scroll-position-2.0.4.tgz",
-      "integrity": "sha512-5ugiHqQ1OptBmujOsJGigbUt/rQ826+8RKYSpBp1uax1eF7TlpigXt6mS1PDsJIyEauHi8rjH5B3weOn1//tug==",
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/use-update-effect": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nextui-org/use-update-effect/-/use-update-effect-2.0.4.tgz",
-      "integrity": "sha512-HycSl9Eopmy3ypZQxXVR7eov2D0q0zcgldgbIPvlKExbj8OInaIImc9zLMI9oQgfmg/YdvLeFSrfwc5BPrIvlg==",
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@nextui-org/user": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/@nextui-org/user/-/user-2.0.25.tgz",
-      "integrity": "sha512-Ykh65O0ynJBlstlZowM8KrX6zv/VLfDgYX892Dk0goLwU8gcSILPZE7yGIBZi1XsNN7mE3dmTp/APLFDbkzzXw==",
-      "dependencies": {
-        "@nextui-org/avatar": "2.0.24",
-        "@nextui-org/react-utils": "2.0.10",
-        "@nextui-org/shared-utils": "2.0.4",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/utils": "^3.21.1"
-      },
-      "peerDependencies": {
-        "@nextui-org/system": ">=2.0.0",
-        "@nextui-org/theme": ">=2.1.0",
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -1577,6 +2370,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -1585,6 +2379,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -1593,387 +2388,515 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@react-aria/breadcrumbs": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.5.11.tgz",
-      "integrity": "sha512-bQz4g2tKvcWxeqPGj9O0RQf++Ka8f2o/pJMJB+QQ27DVQWhxpQpND//oFku2aFYkxHB/fyD9qVoiqpQR25bidw==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.5.32.tgz",
+      "integrity": "sha512-S61vh5DJ2PXiXUwD7gk+pvS/b4VPrc3ZJOUZ0yVRLHkVESr5LhIZH+SAVgZkm1lzKyMRG+BH+fiRH/DZRSs7SA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/link": "^3.6.5",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/breadcrumbs": "^3.7.3",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/link": "^3.8.9",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/breadcrumbs": "^3.7.19",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/button": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.9.3.tgz",
-      "integrity": "sha512-ZXo2VGTxfbaTEnfeIlm5ym4vYpGAy8sGrad8Scv+EyDAJWLMKokqctfaN6YSWbqUApC3FN63IvMqASflbmnYig==",
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.14.5.tgz",
+      "integrity": "sha512-ZuLx+wQj9VQhH9BYe7t0JowmKnns2XrFHFNvIVBb5RwxL+CIycIOL7brhWKg2rGdxvlOom7jhVbcjSmtAaSyaQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/toggle": "^3.7.2",
-        "@react-types/button": "^3.9.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/toolbar": "3.0.0-beta.24",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/toggle": "^3.9.5",
+        "@react-types/button": "^3.15.1",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/calendar": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/calendar/-/calendar-3.9.5.tgz",
+      "integrity": "sha512-k0kvceYdZZu+DoeqephtlmIvh1CxqdFyoN52iqVzTz9O0pe5Xfhq7zxPGbeCp4pC61xzp8Lu/6uFA/YNfQQNag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/calendar": "^3.9.3",
+        "@react-types/button": "^3.15.1",
+        "@react-types/calendar": "^3.8.3",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/checkbox": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.14.1.tgz",
-      "integrity": "sha512-b4rtrg5SpRSa9jBOqzJMmprJ+jDi3KyVvUh+DsvISe5Ti7gVAhMBgnca1D0xBp22w2jhk/o4gyu1bYxGLum0GA==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.16.5.tgz",
+      "integrity": "sha512-ZhUT7ELuD52hb+Zpzw0ElLQiVOd5sKYahrh+PK3vq13Wk5TedBscALpjuXetI4pwFfdmAM1Lhgcsrd8+6AmyvA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/form": "^3.0.3",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/label": "^3.7.6",
-        "@react-aria/toggle": "^3.10.2",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/checkbox": "^3.6.3",
-        "@react-stately/form": "^3.0.1",
-        "@react-stately/toggle": "^3.7.2",
-        "@react-types/checkbox": "^3.7.1",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/toggle": "^3.12.5",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/checkbox": "^3.7.5",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/toggle": "^3.9.5",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/combobox": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/@react-aria/combobox/-/combobox-3.8.4.tgz",
-      "integrity": "sha512-HyTWIo2B/0xq0Of+sDEZCfJyf4BvCvDYIWG4UhjqL1kHIHIGQyyr+SldbVUjXVYnk8pP1eGB3ttiREujjjALPQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/combobox/-/combobox-3.15.0.tgz",
+      "integrity": "sha512-qSjQTFwKl3x1jCP2NRSJ6doZqAp6c2GTfoiFwWjaWg1IewwLsglaW6NnzqRDFiqFbDGgXPn4MqtC1VYEJ3NEjA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/listbox": "^3.11.5",
-        "@react-aria/live-announcer": "^3.3.2",
-        "@react-aria/menu": "^3.13.1",
-        "@react-aria/overlays": "^3.21.1",
-        "@react-aria/selection": "^3.17.5",
-        "@react-aria/textfield": "^3.14.3",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/combobox": "^3.8.2",
-        "@react-stately/form": "^3.0.1",
-        "@react-types/button": "^3.9.2",
-        "@react-types/combobox": "^3.10.1",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/listbox": "^3.15.3",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/menu": "^3.21.0",
+        "@react-aria/overlays": "^3.31.2",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/textfield": "^3.18.5",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/combobox": "^3.13.0",
+        "@react-stately/form": "^3.2.4",
+        "@react-types/button": "^3.15.1",
+        "@react-types/combobox": "^3.14.0",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/datepicker": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/datepicker/-/datepicker-3.16.1.tgz",
+      "integrity": "sha512-6BltCVWt09yefTkGjb2gViGCwoddx9HKJiZbY9u6Es/Q+VhwNJQRtczbnZ3K32p262hIknukNf/5nZaCOI1AKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/spinbutton": "^3.7.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/datepicker": "^3.16.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-types/button": "^3.15.1",
+        "@react-types/calendar": "^3.8.3",
+        "@react-types/datepicker": "^3.13.5",
+        "@react-types/dialog": "^3.5.24",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/dialog": {
-      "version": "3.5.12",
-      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.12.tgz",
-      "integrity": "sha512-7UJR/h/Y364u6Ltpw0bT51B48FybTuIBacGpEJN5IxZlpxvQt0KQcBDiOWfAa/GQogw4B5hH6agaOO0nJcP49Q==",
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.34.tgz",
+      "integrity": "sha512-/x53Q5ynpW5Kv9637WYu7SrDfj3woSp6jJRj8l6teGnWW/iNZWYJETgzHfbxx+HPKYATCZesRoIeO2LnYIXyEA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/overlays": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/dialog": "^3.5.8",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/overlays": "^3.31.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/dialog": "^3.5.24",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/focus": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.16.2.tgz",
-      "integrity": "sha512-Rqo9ummmgotESfypzFjI3uh58yMpL+E+lJBbQuXkBM0u0cU2YYzu0uOrFrq3zcHk997udZvq1pGK/R+2xk9B7g==",
+      "version": "3.21.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.5.tgz",
+      "integrity": "sha512-V18fwCyf8zqgJdpLQeDU5ZRNd9TeOfBbhLgmX77Zr5ae9XwaoJ1R3SFJG1wCJX60t34AW+aLZSEEK+saQElf3Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0",
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/focus/node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-      "engines": {
-        "node": ">=6"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/form": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@react-aria/form/-/form-3.0.3.tgz",
-      "integrity": "sha512-5Q2BHE4TTPDzGY2npCzpRRYshwWUb3SMUA/Cbz7QfEtBk+NYuVaq3KjvqLqgUUdyKtqLZ9Far0kIAexloOC4jw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/form/-/form-3.1.5.tgz",
+      "integrity": "sha512-BWlONgHn8hmaMkcS6AgMSLQeNqVBwqPNLhdqjDO/PCfzvV7O8NZw/dFeIzJwfG4aBfSpbHHRdXGdfrk3d8dylQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/form": "^3.0.1",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/grid": {
-      "version": "3.8.8",
-      "resolved": "https://registry.npmjs.org/@react-aria/grid/-/grid-3.8.8.tgz",
-      "integrity": "sha512-7Bzbya4tO0oIgqexwRb8D6ZdC0GASYq9f/pnkrqocgvG9e1SCld4zOioKbYQDvAK/NnbCgXmmdqFAcLM/iazaA==",
+      "version": "3.14.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/grid/-/grid-3.14.8.tgz",
+      "integrity": "sha512-X6rRFKDu/Kh6Sv8FBap3vjcb+z4jXkSOwkYnexIJp5kMTo5/Dqo55cCBio5B70Tanfv32Ev/6SpzYG7ryxnM9w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/live-announcer": "^3.3.2",
-        "@react-aria/selection": "^3.17.5",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/grid": "^3.8.5",
-        "@react-stately/selection": "^3.14.3",
-        "@react-stately/virtualizer": "^3.6.8",
-        "@react-types/checkbox": "^3.7.1",
-        "@react-types/grid": "^3.2.4",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/grid": "^3.11.9",
+        "@react-stately/selection": "^3.20.9",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/i18n": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.10.2.tgz",
-      "integrity": "sha512-Z1ormoIvMOI4mEdcFLYsoJy9w/EzBdBmgfLP+S/Ah+1xwQOXpgwZxiKOhYHpWa0lf6hkKJL34N9MHJvCJ5Crvw==",
+      "version": "3.12.16",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.16.tgz",
+      "integrity": "sha512-Km2CAz6MFQOUEaattaW+2jBdWOHUF8WX7VQoNbjlqElCP58nSaqi9yxTWUDRhAcn8/xFUnkFh4MFweNgtrHuEA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@internationalized/date": "^3.5.2",
-        "@internationalized/message": "^3.1.2",
-        "@internationalized/number": "^3.5.1",
-        "@internationalized/string": "^3.2.1",
-        "@react-aria/ssr": "^3.9.2",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
+        "@internationalized/date": "^3.12.0",
+        "@internationalized/message": "^3.1.8",
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/interactions": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.1.tgz",
-      "integrity": "sha512-AlHf5SOzsShkHfV8GLLk3v9lEmYqYHURKcXWue0JdYbmquMRkUsf/+Tjl1+zHVAQ8lKqRnPYbTmc4AcZbqxltw==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.27.1.tgz",
+      "integrity": "sha512-M3wLpTTmDflI0QGNK0PJNUaBXXfeBXue8ZxLMngfc1piHNiH4G5lUvWd9W14XVbqrSCVY8i8DfGrNYpyyZu0tw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/ssr": "^3.9.2",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/flags": "^3.1.2",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/label": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.7.6.tgz",
-      "integrity": "sha512-ap9iFS+6RUOqeW/F2JoNpERqMn1PvVIo3tTMrJ1TY1tIwyJOxdCBRgx9yjnPBnr+Ywguep+fkPNNi/m74+tXVQ==",
+      "version": "3.7.25",
+      "resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.7.25.tgz",
+      "integrity": "sha512-oNK3Pqj4LDPwEbQaoM/uCip4QvQmmwGOh08VeW+vzSi6TAwf+KoWTyH/tiAeB0CHWNDK0k3e1iTygTAt4wzBmg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/landmark": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/landmark/-/landmark-3.0.10.tgz",
+      "integrity": "sha512-GpNjJaI8/a6WxYDZgzTCLYSzPM6xp2pxCIQ4udiGbTCtxx13Trmm0cPABvPtzELidgolCf05em9Phr+3G0eE8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/link": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/@react-aria/link/-/link-3.6.5.tgz",
-      "integrity": "sha512-kg8CxKqkciQFzODvLAfxEs8gbqNXFZCW/ISOE2LHYKbh9pA144LVo71qO3SPeYVVzIjmZeW4vEMdZwqkNozecw==",
+      "version": "3.8.9",
+      "resolved": "https://registry.npmjs.org/@react-aria/link/-/link-3.8.9.tgz",
+      "integrity": "sha512-UaAFBfs84/Qq6TxlMWkREqqNY6SFLukot+z2Aa1kC+VyStv1kWG6sE5QLjm4SBn1Q3CGRsefhB/5+taaIbB4Pw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/link": "^3.5.3",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/link": "^3.6.7",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/listbox": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.11.5.tgz",
-      "integrity": "sha512-y3a3zQYjT+JKgugCMMKS7K9sRoCoP1Z6Fiiyfd77OHXWzh9RlnvWGsseljynmbxLzSuPwFtCYkU1Jz4QwsPUIg==",
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.15.3.tgz",
+      "integrity": "sha512-C6YgiyrHS5sbS5UBdxGMhEs+EKJYotJgGVtl9l0ySXpBUXERiHJWLOyV7a8PwkUOmepbB4FaLD7Y9EUzGkrGlw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/label": "^3.7.6",
-        "@react-aria/selection": "^3.17.5",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/list": "^3.10.3",
-        "@react-types/listbox": "^3.4.7",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/list": "^3.13.4",
+        "@react-types/listbox": "^3.7.6",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/live-announcer": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/live-announcer/-/live-announcer-3.3.2.tgz",
-      "integrity": "sha512-aOyPcsfyY9tLCBhuUaYCruwcd1IrYLc47Ou+J7wMzjeN9v4lsaEfiN12WFl8pDqOwfy6/7It2wmlm5hOuZY8wQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/live-announcer/-/live-announcer-3.4.4.tgz",
+      "integrity": "sha512-PTTBIjNRnrdJOIRTDGNifY2d//kA7GUAwRFJNOEwSNG4FW+Bq9awqLiflw0JkpyB0VNIwou6lqKPHZVLsGWOXA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@react-aria/menu": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.13.1.tgz",
-      "integrity": "sha512-jF80YIcvD16Fgwm5pj7ViUE3Dj7z5iewQixLaFVdvpgfyE58SD/ZVU9/JkK5g/03DYM0sjpUKZGkdFxxw8eKnw==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.21.0.tgz",
+      "integrity": "sha512-CKTVZ4izSE1eKIti6TbTtzJAUo+WT8O4JC0XZCYDBpa0f++lD19Kz9aY+iY1buv5xGI20gAfpO474E9oEd4aQA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/overlays": "^3.21.1",
-        "@react-aria/selection": "^3.17.5",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/menu": "^3.6.1",
-        "@react-stately/tree": "^3.7.6",
-        "@react-types/button": "^3.9.2",
-        "@react-types/menu": "^3.9.7",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/overlays": "^3.31.2",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/menu": "^3.9.11",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/tree": "^3.9.6",
+        "@react-types/button": "^3.15.1",
+        "@react-types/menu": "^3.10.7",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/numberfield": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/numberfield/-/numberfield-3.12.5.tgz",
+      "integrity": "sha512-Fi41IUWXEHLFIeJ/LHuZ9Azs8J/P563fZi37GSBkIq5P1pNt1rPgJJng5CNn4KsHxwqadTRUlbbZwbZraWDtRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/spinbutton": "^3.7.2",
+        "@react-aria/textfield": "^3.18.5",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/numberfield": "^3.11.0",
+        "@react-types/button": "^3.15.1",
+        "@react-types/numberfield": "^3.8.18",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/overlays": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.21.1.tgz",
-      "integrity": "sha512-djEBDF+TbIIOHWWNpdm19+z8xtY8U+T+wKVQg/UZ6oWnclSqSWeGl70vu73Cg4HVBJ4hKf1SRx4Z/RN6VvH4Yw==",
+      "version": "3.31.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.31.2.tgz",
+      "integrity": "sha512-78HYI08r6LvcfD34gyv19ArRIjy1qxOKuXl/jYnjLDyQzD4pVb634IQWcm0zt10RdKgyuH6HTqvuDOgZTLet7Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/ssr": "^3.9.2",
-        "@react-aria/utils": "^3.23.2",
-        "@react-aria/visually-hidden": "^3.8.10",
-        "@react-stately/overlays": "^3.6.5",
-        "@react-types/button": "^3.9.2",
-        "@react-types/overlays": "^3.8.5",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-aria/visually-hidden": "^3.8.31",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-types/button": "^3.15.1",
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/progress": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/@react-aria/progress/-/progress-3.4.11.tgz",
-      "integrity": "sha512-RePHbS15/KYFiApYLdwazwvWKsB9q0Kn5DGCSb0hqCC+k2Eui8iVVOsegswiP+xqkk/TiUCIkBEw22W3Az4kTg==",
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@react-aria/progress/-/progress-3.4.30.tgz",
+      "integrity": "sha512-S6OWVGgluSWYSd/A6O8CVjz83eeMUfkuWSra0ewAV9bmxZ7TP9pUmD3bGdqHZEl97nt5vHGjZ3eq/x8eCmzKhA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/label": "^3.7.6",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/progress": "^3.5.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/progress": "^3.5.18",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/radio": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.10.2.tgz",
-      "integrity": "sha512-CTUTR+qt3BLjmyQvKHZuVm+1kyvT72ZptOty++sowKXgJApTLdjq8so1IpaLAr8JIfzqD5I4tovsYwIQOX8log==",
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.12.5.tgz",
+      "integrity": "sha512-8CCJKJzfozEiWBPO9QAATG1rBGJEJ+xoqvHf9LKU2sPFGsA2/SRnLs6LB9fCG5R3spvaK1xz0any1fjWPl7x8A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/form": "^3.0.3",
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/label": "^3.7.6",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/radio": "^3.10.2",
-        "@react-types/radio": "^3.7.1",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/radio": "^3.11.5",
+        "@react-types/radio": "^3.9.4",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/selection": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.17.5.tgz",
-      "integrity": "sha512-gO5jBUkc7WdkiFMlWt3x9pTSuj3Yeegsxfo44qU5NPlKrnGtPRZDWrlACNgkDHu645RNNPhlyoX0C+G8mUg1xA==",
+      "version": "3.27.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.27.2.tgz",
+      "integrity": "sha512-GbUSSLX/ciXix95KW1g+SLM9np7iXpIZrFDSXkC6oNx1uhy18eAcuTkeZE25+SY5USVUmEzjI3m/3JoSUcebbg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/selection": "^3.14.3",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/selection": "^3.20.9",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/slider": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.7.6.tgz",
-      "integrity": "sha512-ZeZhyHzhk9gxGuThPKgX2K3RKsxPxsFig1iYoJvqP8485NtHYQIPht2YcpEKA9siLxGF0DR9VCfouVhSoW0AEA==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.8.5.tgz",
+      "integrity": "sha512-gqkJxznk141mE0JamXF5CXml9PDbPkBz8dyKlihtWHWX4yhEbVYdC9J0otE7iCR3zx69Bm7WHoTGL0BsdpKzVA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/label": "^3.7.6",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/slider": "^3.5.2",
-        "@react-types/shared": "^3.22.1",
-        "@react-types/slider": "^3.7.1",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/slider": "^3.7.5",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/slider": "^3.8.4",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/spinbutton/-/spinbutton-3.7.2.tgz",
+      "integrity": "sha512-adjE1wNCWlugvAtVXlXWPtIG9JWurEgYVn1Eeyh19x038+oXGvOsOAoKCXM+SnGleTWQ9J7pEZITFoEI3cVfAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/button": "^3.15.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/ssr": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.2.tgz",
-      "integrity": "sha512-0gKkgDYdnq1w+ey8KzG9l+H5Z821qh9vVjztk55rUg71vTk/Eaebeir+WtzcLLwTjw3m/asIjx8Y59y1lJZhBw==",
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
+      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       },
@@ -1981,857 +2904,1026 @@
         "node": ">= 12"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/switch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.6.2.tgz",
-      "integrity": "sha512-X5m/omyhXK+V/vhJFsHuRs2zmt9Asa/RuzlldbXnWohLdeuHMPgQnV8C9hg3f+sRi3sh9UUZ64H61pCtRoZNwg==",
+      "version": "3.7.11",
+      "resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.7.11.tgz",
+      "integrity": "sha512-dYVX71HiepBsKyeMaQgHbhqI+MQ3MVoTd5EnTbUjefIBnmQZavYj1/e4NUiUI4Ix+/C0HxL8ibDAv4NlSW3eLQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/toggle": "^3.10.2",
-        "@react-stately/toggle": "^3.7.2",
-        "@react-types/switch": "^3.5.1",
+        "@react-aria/toggle": "^3.12.5",
+        "@react-stately/toggle": "^3.9.5",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/switch": "^3.5.17",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/table": {
-      "version": "3.13.5",
-      "resolved": "https://registry.npmjs.org/@react-aria/table/-/table-3.13.5.tgz",
-      "integrity": "sha512-P2nHEDk2CCoEbMFKNCyBC9qvmv7F/IXARDt/7z/J4mKFgU2iNSK+/zw6yrb38q33Zlk8hDaqSYNxHlMrh+/1MQ==",
+      "version": "3.17.11",
+      "resolved": "https://registry.npmjs.org/@react-aria/table/-/table-3.17.11.tgz",
+      "integrity": "sha512-GkYmWPiW3OM+FUZxdS33teHXHXde7TjHuYgDDaG9phvg6cQTQjGilJozrzA3OfftTOq5VB8XcKTIQW3c0tpYsQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/grid": "^3.8.8",
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/live-announcer": "^3.3.2",
-        "@react-aria/utils": "^3.23.2",
-        "@react-aria/visually-hidden": "^3.8.10",
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/flags": "^3.0.1",
-        "@react-stately/table": "^3.11.6",
-        "@react-stately/virtualizer": "^3.6.8",
-        "@react-types/checkbox": "^3.7.1",
-        "@react-types/grid": "^3.2.4",
-        "@react-types/shared": "^3.22.1",
-        "@react-types/table": "^3.9.3",
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/grid": "^3.14.8",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.33.1",
+        "@react-aria/visually-hidden": "^3.8.31",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/table": "^3.15.4",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/table": "^3.13.6",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/tabs": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.8.5.tgz",
-      "integrity": "sha512-Jvt33/W+66n5oCxVwHAYarJ3Fit61vULiPcG7uTez0Mf11cq/C72wOrj+ZuNz6PTLTi2veBNQ7MauY72SnOjRg==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.11.1.tgz",
+      "integrity": "sha512-3Ppz7yaEDW9L7p9PE9yNOl5caLwNnnLQqI+MX/dwbWlw9HluHS7uIjb21oswNl6UbSxAWyENOka45+KN4Fkh7A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/selection": "^3.17.5",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/tabs": "^3.6.4",
-        "@react-types/shared": "^3.22.1",
-        "@react-types/tabs": "^3.3.5",
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/tabs": "^3.8.9",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/tabs": "^3.3.22",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/textfield": {
-      "version": "3.14.3",
-      "resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.14.3.tgz",
-      "integrity": "sha512-wPSjj/mTABspYQdahg+l5YMtEQ3m5iPCTtb5g6nR1U1rzJkvS4i5Pug6PUXeLeMz2H3ToflPWGlNOqBioAFaOQ==",
+      "version": "3.18.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.18.5.tgz",
+      "integrity": "sha512-ttwVSuwoV3RPaG2k2QzEXKeQNQ3mbdl/2yy6I4Tjrn1ZNkYHfVyJJ26AjenfSmj1kkTQoSAfZ8p+7rZp4n0xoQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/form": "^3.0.3",
-        "@react-aria/label": "^3.7.6",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/form": "^3.0.1",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/shared": "^3.22.1",
-        "@react-types/textfield": "^3.9.1",
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/textfield": "^3.12.8",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toast": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@react-aria/toast/-/toast-3.0.11.tgz",
+      "integrity": "sha512-2DjZjBAvm8/CWbnZ6s7LjkYCkULKtjMve6GvhPTq98AthuEDLEiBvM1wa3xdecCRhZyRT1g6DXqVca0EfZ9fJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/landmark": "^3.0.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/toast": "^3.1.3",
+        "@react-types/button": "^3.15.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/toggle": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.10.2.tgz",
-      "integrity": "sha512-DgitscHWgI6IFgnvp2HcMpLGX/cAn+XX9kF5RJQbRQ9NqUgruU5cEEGSOLMrEJ6zXDa2xmOiQ+kINcyNhA+JLg==",
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.12.5.tgz",
+      "integrity": "sha512-XXVFLzcV8fr9mz7y/wfxEAhWvaBZ9jSfhCMuxH2bsivO7nTcMJ1jb4g2xJNwZgne17bMWNc7mKvW5dbsdlI6BA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/toggle": "^3.7.2",
-        "@react-types/checkbox": "^3.7.1",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/toggle": "^3.9.5",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toolbar": {
+      "version": "3.0.0-beta.24",
+      "resolved": "https://registry.npmjs.org/@react-aria/toolbar/-/toolbar-3.0.0-beta.24.tgz",
+      "integrity": "sha512-B2Rmpko7Ghi2RbNfsGdbR7I+RQBDhPGVE4bU3/EwHz+P/vNe5LyGPTeSwqaOMsQTF9lKNCkY8424dVTCr6RUMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/tooltip": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.7.2.tgz",
-      "integrity": "sha512-6jXOSGPao3gPgUQWLbH2r/jxGMqIaIKrJgfwu9TQrh+UkwwiTYW20EpEDCYY2nRFlcoi7EYAiPDSEbHCwXS7Lg==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.9.2.tgz",
+      "integrity": "sha512-VrgkPwHiEnAnBhoQ4W7kfry/RfVuRWrUPaJSp0+wKM6u0gg2tmn7OFRDXTxBAm/omQUguIdIjRWg7sf3zHH82A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/tooltip": "^3.4.7",
-        "@react-types/shared": "^3.22.1",
-        "@react-types/tooltip": "^3.4.7",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/tooltip": "^3.5.11",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/tooltip": "^3.5.2",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/utils": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.23.2.tgz",
-      "integrity": "sha512-yznR9jJ0GG+YJvTMZxijQwVp+ahP66DY0apZf7X+dllyN+ByEDW+yaL1ewYPIpugxVzH5P8jhnBXsIyHKN411g==",
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.33.1.tgz",
+      "integrity": "sha512-kIx1Sj6bbAT0pdqCegHuPanR9zrLn5zMRiM7LN12rgRf55S19ptd9g3ncahArifYTRkfEU9VIn+q0HjfMqS9/w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/ssr": "^3.9.2",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0",
         "clsx": "^2.0.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/utils/node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-      "engines": {
-        "node": ">=6"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/visually-hidden": {
-      "version": "3.8.10",
-      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.10.tgz",
-      "integrity": "sha512-np8c4wxdbE7ZrMv/bnjwEfpX0/nkWy9sELEb0sK8n4+HJ+WycoXXrVxBUb9tXgL/GCx5ReeDQChjQWwajm/z3A==",
+      "version": "3.8.31",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.31.tgz",
+      "integrity": "sha512-RTOHHa4n56a9A3criThqFHBifvZoV71+MCkSuNP2cKO662SUWjqKkd0tJt/mBRMEJPkys8K7Eirp6T8Wt5FFRA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/calendar": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/calendar/-/calendar-3.9.3.tgz",
+      "integrity": "sha512-uw7fCZXoypSBBUsVkbNvJMQWTihZReRbyLIGG3o/ZM630N3OCZhb/h4Uxke4pNu7n527H0V1bAnZgAldIzOYqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/calendar": "^3.8.3",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/checkbox": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.6.3.tgz",
-      "integrity": "sha512-hWp0GXVbMI4sS2NbBjWgOnHNrRqSV4jeftP8zc5JsIYRmrWBUZitxluB34QuVPzrBO29bGsF0GTArSiQZt6BWw==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.7.5.tgz",
+      "integrity": "sha512-K5R5ted7AxLB3sDkuVAazUdyRMraFT1imVqij2GuAiOUFvsZvbuocnDuFkBVKojyV3GpqLBvViV8IaCMc4hNIw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-stately/form": "^3.0.1",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/checkbox": "^3.7.1",
-        "@react-types/shared": "^3.22.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/collections": {
-      "version": "3.10.5",
-      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.10.5.tgz",
-      "integrity": "sha512-k8Q29Nnvb7iAia1QvTanZsrWP2aqVNBy/1SlE6kLL6vDqtKZC+Esd1SDLHRmIcYIp5aTdfwIGd0NuiRQA7a81Q==",
+      "version": "3.12.10",
+      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.10.tgz",
+      "integrity": "sha512-wmF9VxJDyBujBuQ76vXj2g/+bnnj8fx5DdXgRmyfkkYhPB46+g2qnjbVGEvipo7bJuGxDftCUC4SN7l7xqUWfg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/combobox": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.8.2.tgz",
-      "integrity": "sha512-f+IHuFW848VoMbvTfSakn2WIh2urDxO355LrKxnisXPCkpQHpq3lvT2mJtKJwkPxjAy7xPjpV8ejgga2R6p53Q==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.13.0.tgz",
+      "integrity": "sha512-dX9g/cK1hjLRjcbWVF6keHxTQDGhKGB2QAgPhWcBmOK3qJv+2dQqsJ6YCGWn/Y2N2acoEseLrAA7+Qe4HWV9cg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/form": "^3.0.1",
-        "@react-stately/list": "^3.10.3",
-        "@react-stately/overlays": "^3.6.5",
-        "@react-stately/select": "^3.6.2",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/combobox": "^3.10.1",
-        "@react-types/shared": "^3.22.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/list": "^3.13.4",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/combobox": "^3.14.0",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/datepicker": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/datepicker/-/datepicker-3.16.1.tgz",
+      "integrity": "sha512-BtAMDvxd1OZxkxjqq5tN5TYmp6Hm8+o3+IDA4qmem2/pfQfVbOZeWS2WitcPBImj4n4T+W1A5+PI7mT/6DUBVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/datepicker": "^3.13.5",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/flags": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.0.1.tgz",
-      "integrity": "sha512-h5PcDMj54aipQNO18ig/IMI1kzPwcvSwVq5M6Ib6XE1WIkOH0dIuW2eADdAOhcGi3KXJtXVdD29zh0Eox1TKgQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
+      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@swc/helpers": "^0.4.14"
-      }
-    },
-    "node_modules/@react-stately/flags/node_modules/@swc/helpers": {
-      "version": "0.4.36",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.36.tgz",
-      "integrity": "sha512-5lxnyLEYFskErRPenYItLRSge5DjrJngYKdVjRSrWfza9G6KkgHEXi0vUZiyUeMU5JfXH1YnvXZzSp8ul88o2Q==",
-      "dependencies": {
-        "legacy-swc-helpers": "npm:@swc/helpers@=0.4.14",
-        "tslib": "^2.4.0"
+        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@react-stately/form": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/form/-/form-3.0.1.tgz",
-      "integrity": "sha512-T1Ul2Ou0uE/S4ECLcGKa0OfXjffdjEHfUFZAk7OZl0Mqq/F7dl5WpoLWJ4d4IyvZzGO6anFNenP+vODWbrF3NA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/form/-/form-3.2.4.tgz",
+      "integrity": "sha512-qNBzun8SbLdgahryhKLqL1eqP+MXY6as82sVXYOOvUYLzgU5uuN8mObxYlxJgMI5akSdQJQV3RzyfVobPRE7Kw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/grid": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.8.5.tgz",
-      "integrity": "sha512-KCzi0x0p1ZKK+OptonvJqMbn6Vlgo6GfOIlgcDd0dNYDP8TJ+3QFJAFre5mCr7Fubx7LcAOio4Rij0l/R8fkXQ==",
+      "version": "3.11.9",
+      "resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.11.9.tgz",
+      "integrity": "sha512-qQY6F+27iZRn30dt0ZOrSetUmbmNJ0pLe9Weuqw3+XDVSuWT+2O/rO1UUYeK+mO0Acjzdv+IWiYbu9RKf2wS9w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/selection": "^3.14.3",
-        "@react-types/grid": "^3.2.4",
-        "@react-types/shared": "^3.22.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/selection": "^3.20.9",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/list": {
-      "version": "3.10.3",
-      "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.10.3.tgz",
-      "integrity": "sha512-Ul8el0tQy2Ucl3qMQ0fiqdJ874W1ZNjURVSgSxN+pGwVLNBVRjd6Fl7YwZFCXER2YOlzkwg+Zqozf/ZlS0EdXA==",
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.13.4.tgz",
+      "integrity": "sha512-HHYSjA9VG7FPSAtpXAjQyM/V7qFHWGg88WmMrDt5QDlTBexwPuH0oFLnW0qaVZpAIxuWIsutZfxRAnme/NhhAA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/selection": "^3.14.3",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/shared": "^3.22.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/menu": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.6.1.tgz",
-      "integrity": "sha512-3v0vkTm/kInuuG8jG7jbxXDBnMQcoDZKWvYsBQq7+POt0LmijbLdbdZPBoz9TkZ3eo/OoP194LLHOaFTQyHhlw==",
+      "version": "3.9.11",
+      "resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.9.11.tgz",
+      "integrity": "sha512-vYkpO9uV2OUecsIkrOc+Urdl/s1xw/ibNH/UXsp4PtjMnS6mK9q2kXZTM3WvMAKoh12iveUO+YkYCZQshmFLHQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-stately/overlays": "^3.6.5",
-        "@react-types/menu": "^3.9.7",
-        "@react-types/shared": "^3.22.1",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-types/menu": "^3.10.7",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/numberfield": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/numberfield/-/numberfield-3.11.0.tgz",
+      "integrity": "sha512-rxfC047vL0LP4tanjinfjKAriAvdVL57Um5RUL5nHML8IOWCB3TBxegQkJ6to6goScC/oZhd0/Y2LSaiRuKbNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/number": "^3.6.5",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/numberfield": "^3.8.18",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/overlays": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.5.tgz",
-      "integrity": "sha512-U4rCFj6TPJPXLUvYXAcvh+yP/CO2W+7f0IuqP7ZZGE+Osk9qFkT+zRK5/6ayhBDFpmueNfjIEAzT9gYPQwNHFw==",
+      "version": "3.6.23",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.23.tgz",
+      "integrity": "sha512-RzWxots9A6gAzQMP4s8hOAHV7SbJRTFSlQbb6ly1nkWQXacOSZSFNGsKOaS0eIatfNPlNnW4NIkgtGws5UYzfw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/overlays": "^3.8.5",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/overlays": "^3.9.4",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/radio": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.10.2.tgz",
-      "integrity": "sha512-JW5ZWiNMKcZvMTsuPeWJQLHXD5rlqy7Qk6fwUx/ZgeibvMBW/NnW19mm2+IMinzmbtERXvR6nsiA837qI+4dew==",
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.11.5.tgz",
+      "integrity": "sha512-QxA779S4ea5icQ0ja7CeiNzY1cj7c9G9TN0m7maAIGiTSinZl2Ia8naZJ0XcbRRp+LBll7RFEdekne15TjvS/w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-stately/form": "^3.0.1",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/radio": "^3.7.1",
-        "@react-types/shared": "^3.22.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/radio": "^3.9.4",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/select": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/select/-/select-3.6.2.tgz",
-      "integrity": "sha512-duOxdHKol93h6Ew6fap6Amz+zngoERKZLSKVm/8I8uaBgkoBhEeTFv7mlpHTgINxymMw3mMrvy6GL/gfKFwkqg==",
-      "dependencies": {
-        "@react-stately/form": "^3.0.1",
-        "@react-stately/list": "^3.10.3",
-        "@react-stately/overlays": "^3.6.5",
-        "@react-types/select": "^3.9.2",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/selection": {
-      "version": "3.14.3",
-      "resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.14.3.tgz",
-      "integrity": "sha512-d/t0rIWieqQ7wjLoMoWnuHEUSMoVXxkPBFuSlJF3F16289FiQ+b8aeKFDzFTYN7fFD8rkZTnpuE4Tcxg3TmA+w==",
+      "version": "3.20.9",
+      "resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.20.9.tgz",
+      "integrity": "sha512-RhxRR5Wovg9EVi3pq7gBPK2BoKmP59tOXDMh2r1PbnGevg/7TNdR67DCEblcmXwHuBNS46ELfKdd0XGHqmS8nQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/shared": "^3.22.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/slider": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.5.2.tgz",
-      "integrity": "sha512-ntH3NLRG+AwVC7q4Dx9DcmMkMh9vmHjHNXAgaoqNjhvwfSIae7sQ69CkVe6XeJjIBy6LlH81Kgapz+ABe5a1ZA==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.7.5.tgz",
+      "integrity": "sha512-OrQMNR5xamLYH52TXtvTgyw3EMwv+JI+1istQgEj1CHBjC9eZZqn5iNCN20tzm+uDPTH0EIGULFjjPIumqYUQg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/shared": "^3.22.1",
-        "@react-types/slider": "^3.7.1",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/slider": "^3.8.4",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/table": {
-      "version": "3.11.6",
-      "resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.11.6.tgz",
-      "integrity": "sha512-34YsfOILXusj3p6QNcKEaDWVORhM6WEhwPSLCZlkwAJvkxuRQFdih5rQKoIDc0uV5aZsB6bYBqiFhnjY0VERhw==",
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.15.4.tgz",
+      "integrity": "sha512-fGaNyw3wv7JgRCNzgyDzpaaTFuSy5f4Qekch4UheMXDJX7dOeaMhUXeOfvnXCVg+BGM4ey/D82RvDOGvPy1Nww==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/flags": "^3.0.1",
-        "@react-stately/grid": "^3.8.5",
-        "@react-stately/selection": "^3.14.3",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/grid": "^3.2.4",
-        "@react-types/shared": "^3.22.1",
-        "@react-types/table": "^3.9.3",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/grid": "^3.11.9",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/table": "^3.13.6",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/tabs": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.6.4.tgz",
-      "integrity": "sha512-WZJgMBqzLgN88RN8AxhY4aH1+I+4w1qQA0Lh3LRSDegaytd+NHixCWaP3IPjePgCB5N1UsPe96Xglw75zjHmDg==",
+      "version": "3.8.9",
+      "resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.8.9.tgz",
+      "integrity": "sha512-AQ4Xrn6YzIolaVShCV9cnwOjBKPAOGP/PTp7wpSEtQbQ0HZzUDG2RG/M4baMeUB2jZ33b7ifXyPcK78o0uOftg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-stately/list": "^3.10.3",
-        "@react-types/shared": "^3.22.1",
-        "@react-types/tabs": "^3.3.5",
+        "@react-stately/list": "^3.13.4",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/tabs": "^3.3.22",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/toast": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/toast/-/toast-3.1.3.tgz",
+      "integrity": "sha512-mT9QJKmD523lqFpOp0VWZ6QHZENFK7HrodnNJDVc7g616s5GNmemdlkITV43fSY3tHeThCVvPu+Uzh7RvQ9mpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/toggle": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.7.2.tgz",
-      "integrity": "sha512-SHCF2btcoK57c4lyhucRbyPBAFpp0Pdp0vcPdn3hUgqbu6e5gE0CwG/mgFmZRAQoc7PRc7XifL0uNw8diJJI0Q==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.9.5.tgz",
+      "integrity": "sha512-PVzXc788q3jH98Kvw1LYDL+wpVC14dCEKjOku8cSaqhEof6AJGaLR9yq+EF1yYSL2dxI6z8ghc0OozY8WrcFcA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/checkbox": "^3.7.1",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/tooltip": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.4.7.tgz",
-      "integrity": "sha512-ACtRgBQ8rphBtsUaaxvEAM0HHN9PvMuyvL0vUHd7jvBDCVZJ6it1BKu9SBKjekBkoBOw9nemtkplh9R2CA6V8Q==",
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.5.11.tgz",
+      "integrity": "sha512-o8PnFXbvDCuVZ4Ht9ahfS6KHwIZjXopvoQ2vUPxv920irdgWEeC+4omgDOnJ/xFvcpmmJAmSsrQsTQrTguDUQA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-stately/overlays": "^3.6.5",
-        "@react-types/tooltip": "^3.4.7",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-types/tooltip": "^3.5.2",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/tree": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.7.6.tgz",
-      "integrity": "sha512-y8KvEoZX6+YvqjNCVGS3zA/BKw4D3XrUtUKIDme3gu5Mn6z97u+hUXKdXVCniZR7yvV3fHAIXwE5V2K8Oit4aw==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.9.6.tgz",
+      "integrity": "sha512-JCuhGyX2A+PAMsx2pRSwArfqNFZJ9JSPkDaOQJS8MFPAsBe5HemvXsdmv9aBIMzlbCYcVq6EsrFnzbVVTBt/6w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/selection": "^3.14.3",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/shared": "^3.22.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/utils": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.9.1.tgz",
-      "integrity": "sha512-yzw75GE0iUWiyps02BOAPTrybcsMIxEJlzXqtvllAb01O9uX5n0i3X+u2eCpj2UoDF4zS08Ps0jPgWxg8xEYtA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.11.0.tgz",
+      "integrity": "sha512-8LZpYowJ9eZmmYLpudbo/eclIRnbhWIJZ994ncmlKlouNzKohtM8qTC6B1w1pwUbiwGdUoyzLuQbeaIor5Dvcw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/virtualizer": {
-      "version": "3.6.8",
-      "resolved": "https://registry.npmjs.org/@react-stately/virtualizer/-/virtualizer-3.6.8.tgz",
-      "integrity": "sha512-Pf06ihTwExRJltGhi72tmLIo0pcjkL55nu7ifMafAAdxZK4ONxRLSuUjjpvYf/0Rs92xRZy2t/XmHREnfirdkQ==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/virtualizer/-/virtualizer-4.4.6.tgz",
+      "integrity": "sha512-9SfXgLFB61/8SXNLfg5ARx9jAK4m03Aw6/Cg8mdZN24SYarL4TKNRpfw8K/HHVU/bi6WHSJypk6Z/z19o/ztrg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
+        "@react-types/shared": "^3.33.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/accordion": {
-      "version": "3.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/@react-types/accordion/-/accordion-3.0.0-alpha.17.tgz",
-      "integrity": "sha512-Wsp31bYRu9wy4zAAV2W8FLvVGFF3Vk/JKn2MxqhzaSHwHBw/dfgJTvRRUW+OmBgnqVN97ur893TP9A3odpoZEg==",
+      "version": "3.0.0-alpha.26",
+      "resolved": "https://registry.npmjs.org/@react-types/accordion/-/accordion-3.0.0-alpha.26.tgz",
+      "integrity": "sha512-OXf/kXcD2vFlEnkcZy/GG+a/1xO9BN7Uh3/5/Ceuj9z2E/WwD55YwU3GFM5zzkZ4+DMkdowHnZX37XnmbyD3Mg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.21.0"
+        "@react-types/shared": "^3.27.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/breadcrumbs": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.7.3.tgz",
-      "integrity": "sha512-eFto/+6J+JR58vThNcALZRA1OlqlG3GzQ/bq3q8IrrkOZcrfbEJJCWit/+53Ia98siJKuF4OJHnotxIVIz5I3w==",
+      "version": "3.7.19",
+      "resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.7.19.tgz",
+      "integrity": "sha512-AnkyYYmzaM2QFi/N0P/kQLM8tHOyFi7p397B/jEMucXDfwMw5Ny1ObCXeIEqbh8KrIa2Xp8SxmQlCV+8FPs4LA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/link": "^3.5.3",
-        "@react-types/shared": "^3.22.1"
+        "@react-types/link": "^3.6.7",
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/button": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.9.2.tgz",
-      "integrity": "sha512-EnPTkGHZRtiwAoJy5q9lDjoG30bEzA/qnvKG29VVXKYAGeqY2IlFs1ypmU+z1X/CpJgPcG3I5cakM7yTVm3pSg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.15.1.tgz",
+      "integrity": "sha512-M1HtsKreJkigCnqceuIT22hDJBSStbPimnpmQmsl7SNyqCFY3+DHS7y/Sl3GvqCkzxF7j9UTL0dG38lGQ3K4xQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/calendar": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.8.3.tgz",
+      "integrity": "sha512-fpH6WNXotzH0TlKHXXxtjeLZ7ko0sbyHmwDAwmDFyP7T0Iwn1YQZ+lhceLifvynlxuOgX6oBItyUKmkHQ0FouQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/checkbox": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.7.1.tgz",
-      "integrity": "sha512-kuGqjQFex0As/3gfWyk+e9njCcad/ZdnYLLiNvhlk15730xfa0MmnOdpqo9jfuFSXBjOcpxoofvEhvrRMtEdUA==",
+      "version": "3.10.4",
+      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.10.4.tgz",
+      "integrity": "sha512-tYCG0Pd1usEz5hjvBEYcqcA0youx930Rss1QBIse9TgMekA1c2WmPDNupYV8phpO8Zuej3DL1WfBeXcgavK8aw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/combobox": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.10.1.tgz",
-      "integrity": "sha512-XMno1rgVRNta49vf5nV7VJpVSVAV20tt79t618gG1qRKH5Kt2Cy8lz2fQ5vHG6UTv/6jUOvU8g5Pc93sLaTmoA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.14.0.tgz",
+      "integrity": "sha512-zmSSS7BcCOD8rGT8eGbVy7UlL5qq1vm88fFn4WgFe+lfK33ne+E7yTzTxcPY2TCGSo5fY6xMj3OG79FfVNGbSg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/datepicker": {
+      "version": "3.13.5",
+      "resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.13.5.tgz",
+      "integrity": "sha512-j28Vz+xvbb4bj7+9Xbpc4WTvSitlBvt7YEaEGM/8ZQ5g4Jr85H2KwkmDwjzmMN2r6VMQMMYq9JEcemq5wWpfUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@react-types/calendar": "^3.8.3",
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/dialog": {
-      "version": "3.5.8",
-      "resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.8.tgz",
-      "integrity": "sha512-RX8JsMvty8ADHRqVEkppoynXLtN4IzUh8d5z88UEBbcvWKlHfd6bOBQjQcBH3AUue5wjfpPIt6brw2VzgBY/3Q==",
+      "version": "3.5.24",
+      "resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.24.tgz",
+      "integrity": "sha512-NFurEP/zV0dA/41422lV1t+0oh6f/13n+VmLHZG8R13m1J3ql/kAXZ49zBSqkqANBO1ojyugWebk99IiR4pYOw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/overlays": "^3.8.5",
-        "@react-types/shared": "^3.22.1"
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/form": {
+      "version": "3.7.18",
+      "resolved": "https://registry.npmjs.org/@react-types/form/-/form-3.7.18.tgz",
+      "integrity": "sha512-0sBJW0+I9nJcF4SmKrYFEWAlehiebSTy7xqriqAXtqfTEdvzAYLGaAK2/7gx+wlNZeDTdW43CDRJ4XAhyhBqnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/grid": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.2.4.tgz",
-      "integrity": "sha512-sDVoyQcH7MoGdx5nBi5ZOU/mVFBt9YTxhvr0PZ97dMdEHZtJC1w9SuezwWS34f50yb8YAXQRTICbZYcK4bAlDA==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.3.8.tgz",
+      "integrity": "sha512-zJvXH8gc1e1VH2H3LRnHH/W2HIkLkZMH3Cu5pLcj0vDuLBSWpcr3Ikh3jZ+VUOZF0G1Jt1lO8pKIaqFzDLNmLQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/link": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@react-types/link/-/link-3.5.3.tgz",
-      "integrity": "sha512-yVafjW3IejyVnK3oMBNjFABCGG6J27EUG8rvkaGaI1uB6srGUEhpJ97XLv11aj1QkXHBy3VGXqxEV3S7wn4HTw==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@react-types/link/-/link-3.6.7.tgz",
+      "integrity": "sha512-1apXCFJgMC1uydc2KNENrps1qR642FqDpwlNWe254UTpRZn/hEZhA6ImVr8WhomfLJu672WyWA0rUOv4HT+/pQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/listbox": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@react-types/listbox/-/listbox-3.4.7.tgz",
-      "integrity": "sha512-68y5H9CVSPFiwO6MOFxTbry9JQMK/Lb1M9i3M8TDyq1AbJxBPpgAvJ9RaqIMCucsnqCzpY/zA3D/X417zByL1w==",
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/@react-types/listbox/-/listbox-3.7.6.tgz",
+      "integrity": "sha512-335NYElKEByXMalAmeRPyulKIDd2cjOCQhLwvv2BtxO5zaJfZnBbhZs+XPd9zwU6YomyOxODKSHrwbNDx+Jf3w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/menu": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.9.7.tgz",
-      "integrity": "sha512-K6KhloJVoGsqwkdeez72fkNI9dfrmLI/sNrB4XuOKo2crDQ/eyZYWyJmzz8giz/tHME9w774k487rVoefoFh5w==",
+      "version": "3.10.7",
+      "resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.10.7.tgz",
+      "integrity": "sha512-+p7ixZdvPDJZhisqdtWiiuJ9pteNfK5i19NB6wzAw5XkljbEzodNhwLv6rI96DY5XpbFso2kcjw7IWi+rAAGGQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/overlays": "^3.8.5",
-        "@react-types/shared": "^3.22.1"
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/numberfield": {
+      "version": "3.8.18",
+      "resolved": "https://registry.npmjs.org/@react-types/numberfield/-/numberfield-3.8.18.tgz",
+      "integrity": "sha512-nLzk7YAG9yAUtSv+9R8LgCHsu8hJq8/A+m1KsKxvc8WmNJjIujSFgWvT21MWBiUgPBzJKGzAqpMDDa087mltJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/overlays": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.5.tgz",
-      "integrity": "sha512-4D7EEBQigD/m8hE68Ys8eloyyZFHHduqykSIgINJ0edmo0jygRbWlTwuhWFR9USgSP4dK54duN0Mvq0m4HEVEw==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.9.4.tgz",
+      "integrity": "sha512-7Z9HaebMFyYBqtv3XVNHEmVkm7AiYviV7gv0c98elEN2Co+eQcKFGvwBM9Gy/lV57zlTqFX1EX/SAqkMEbCLOA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/progress": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@react-types/progress/-/progress-3.5.2.tgz",
-      "integrity": "sha512-aQql22kusEudsHwDEzq6y/Mh29AM+ftRDKdS5E5g4MkCY5J4FMbOYco1T5So83NIvvG9+eKcxPoJUMjQQACAyA==",
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/@react-types/progress/-/progress-3.5.18.tgz",
+      "integrity": "sha512-mKeQn+KrHr1y0/k7KtrbeDGDaERH6i4f6yBwj/ZtYDCTNKMO3tPHJY6nzF0w/KKZLplIO+BjUbHXc2RVm8ovwQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/radio": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.7.1.tgz",
-      "integrity": "sha512-Zut3rN1odIUBLZdijeyou+UqsLeRE76d9A+npykYGu29ndqmo3w4sLn8QeQcdj1IR71ZnG0pW2Y2BazhK5XrrQ==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.9.4.tgz",
+      "integrity": "sha512-TkMRY3sA1PcFZhhclu4IUzUTIir6MzNJj8h6WT8vO6Nug2kXJ72qigugVFBWJSE472mltduOErEAo0rtAYWbQA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/select": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@react-types/select/-/select-3.9.2.tgz",
-      "integrity": "sha512-fGFrunednY3Pq/BBwVOf87Fsuyo/SlevL0wFIE9OOl2V5NXVaTY7/7RYA8hIOHPzmvsMbndy419BEudiNGhv4A==",
-      "dependencies": {
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/shared": {
-      "version": "3.22.1",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.22.1.tgz",
-      "integrity": "sha512-PCpa+Vo6BKnRMuOEzy5zAZ3/H5tnQg1e80khMhK2xys0j6ZqzkgQC+fHMNZ7VDFNLqqNMj/o0eVeSBDh2POjkw==",
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.33.1.tgz",
+      "integrity": "sha512-oJHtjvLG43VjwemQDadlR5g/8VepK56B/xKO2XORPHt9zlW6IZs3tZrYlvH29BMvoqC7RtE7E5UjgbnbFtDGag==",
+      "license": "Apache-2.0",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/slider": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.7.1.tgz",
-      "integrity": "sha512-FKO3YZYdrBs00XbBW5acP+0L1cCdevl/uRJiXbnLpGysO5PrSFIRS7Wlv4M7ztf6gT7b1Ao4FNC9crbxBr6BzA==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.8.4.tgz",
+      "integrity": "sha512-C+xFVvfKREai9S/ekBDCVaGPOQYkNUAsQhjQnNsUAATaox4I6IYLmcIgLmljpMQWqAe+gZiWsIwacRYMez2Tew==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/switch": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@react-types/switch/-/switch-3.5.1.tgz",
-      "integrity": "sha512-2LFEKMGeufqyYmeN/5dtkDkCPG6x9O4eu6aaBaJmPGon7C/l3yiFEgRue6oCUYc1HixR7Qlp0sPxk0tQeWzrSg==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@react-types/switch/-/switch-3.5.17.tgz",
+      "integrity": "sha512-2GTPJvBCYI8YZ3oerHtXg+qikabIXCMJ6C2wcIJ5Xn0k9XOovowghfJi10OPB2GGyOiLBU74CczP5nx8adG90Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/table": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.9.3.tgz",
-      "integrity": "sha512-Hs/pMbxJdga2zBol4H5pV1FVIiRjCuSTXst6idJjkctanTexR4xkyrtBwl+rdLNoGwQ2pGii49vgklc5bFK7zA==",
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.13.6.tgz",
+      "integrity": "sha512-eluL+iFfnVmFm7OSZrrFG9AUjw+tcv898zbv+NsZACa8oXG1v9AimhZfd+Mo8q/5+sX/9hguWNXFkSvmTjuVPQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/grid": "^3.2.4",
-        "@react-types/shared": "^3.22.1"
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/tabs": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.3.5.tgz",
-      "integrity": "sha512-6NTSZBOWekCtApdZrhu5tHhE/8q52oVohQN+J5T7shAXd6ZAtu8PABVR/nH4BWucc8FL0OUajRqunqzQMU13gA==",
+      "version": "3.3.22",
+      "resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.3.22.tgz",
+      "integrity": "sha512-HGwLD9dA3k3AGfRKGFBhNgxU9/LyRmxN0kxVj1ghA4L9S/qTOzS6GhrGNkGzsGxyVLV4JN8MLxjWN2o9QHnLEg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/textfield": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.9.1.tgz",
-      "integrity": "sha512-JBHY9M2CkL6xFaGSfWmUJVu3tEK09FaeB1dU3IEh6P41xxbFnPakYHSSAdnwMXBtXPoSHIVsUBickW/pjgfe5g==",
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.12.8.tgz",
+      "integrity": "sha512-wt6FcuE5AyntxsnPika/h3nf/DPmeAVbI018L9o6h+B/IL4sMWWdx663wx2KOOeHH8ejKGZQNPLhUKs4s1mVQA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/shared": "^3.22.1"
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/tooltip": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.4.7.tgz",
-      "integrity": "sha512-rV4HZRQxLRNhe24yATOxnFQtGRUmsR7mqxMupXCmd1vrw8h+rdKlQv1zW2q8nALAKNmnRXZJHxYQ1SFzb98fgg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.5.2.tgz",
+      "integrity": "sha512-FvSuZ2WP08NEWefrpCdBYpEEZh/5TvqvGjq0wqGzWg2OPwpc14HjD8aE7I3MOuylXkD4MSlMjl7J4DlvlcCs3Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@react-types/overlays": "^3.8.5",
-        "@react-types/shared": "^3.22.1"
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.63.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.63.0.tgz",
-      "integrity": "sha512-yIgcHnlgv24GxHtVGUhwGqAFDyJkPIC/xjx7HostN08A8yCy8HIfl4JEkTKyBqD1v1L05jNEJOUke4Lf4O1+Qg==",
+      "version": "2.99.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.99.0.tgz",
+      "integrity": "sha512-tHiIST/OEoLmWBE+3X69xRY5srJM/lL86KltmMlIfDo9ePJLo14vQQV9T4NF+P+MoGhCwQL1GTmk51zuAFMXKw==",
+      "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.2.2.tgz",
-      "integrity": "sha512-sJGq1nludmi7pY/fdtCpyY/pYonx7MfHdN408bqb736guWcVI1AChYVbI4kUM978EuOE4Ci6l7bUudfGg07QRw==",
+      "version": "2.99.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.99.0.tgz",
+      "integrity": "sha512-zA9oad6EqGwMLLu2LfP1bXbqKcJGiotAdbdTfZG7YS7619YZQAEgejj9mp+E5vglKE1yMWbKK+S1J3PbuUtgLg==",
+      "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/node-fetch": {
-      "version": "2.6.15",
-      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
-      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "tslib": "2.8.1"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.15.2.tgz",
-      "integrity": "sha512-9/7pUmXExvGuEK1yZhVYXPZnLEkDTwxgMQHXLrN5BwPZZm4iUCL1YEyep/Z2lIZah8d8M433mVAUEGsihUj5KQ==",
+      "version": "2.99.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.99.0.tgz",
+      "integrity": "sha512-8qfOMi2pu9y0IQhUAeFqjrvR49G4ELGevXCWV9qAHXFQ/h2FFh0I8PYjFQj4rHcHSq6hrpozDnS1vbQU8NAQ/A==",
+      "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.9.4.tgz",
-      "integrity": "sha512-wdq+2hZpgw0r2ldRs87d3U08Y8BrsO1bZxPNqbImpYshAEkusDz4vufR8KaqujKxqewmXS6YnUhuRVdvSEIKCA==",
+      "version": "2.99.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.99.0.tgz",
+      "integrity": "sha512-7nFTZhNeANR7FvEY6PfWLCfE8dHqcaJd9SuR7IPEZvBPG9K4uEHMivpjZx4NWRSU7Eji7ZbKy2LG+cJ48DhwHg==",
+      "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14",
-        "@types/phoenix": "^1.5.4",
-        "@types/ws": "^8.5.10",
-        "ws": "^8.14.2"
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/ssr": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.3.0.tgz",
-      "integrity": "sha512-lcVyQ7H6eumb2FB1Wa2N+jYWMfq6CFza3KapikT0fgttMQ+QvDgpNogx9jI8bZgKds+XFSMCojxFvFb+gwdbfA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.9.0.tgz",
+      "integrity": "sha512-UFY6otYV3yqCgV+AyHj80vNkTvbf1Gas2LW4dpbQ4ap6p6v3eB2oaDfcI99jsuJzwVBCFU4BJI+oDYyhNk1z0Q==",
+      "license": "MIT",
       "dependencies": {
-        "cookie": "^0.5.0",
-        "ramda": "^0.29.0"
+        "cookie": "^1.0.2"
       },
       "peerDependencies": {
-        "@supabase/supabase-js": "^2.33.1"
+        "@supabase/supabase-js": "^2.97.0"
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.5.tgz",
-      "integrity": "sha512-OpLoDRjFwClwc2cjTJZG8XviTiQH4Ik8sCiMK5v7et0MDu2QlXjCAW3ljxJB5+z/KazdMOTnySi+hysxWUPu3w==",
+      "version": "2.99.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.99.0.tgz",
+      "integrity": "sha512-mAEEbfsght5EEALejYrwAP9k8sFBGjfMZT8n4SyMXk2iYuWVeRMs1kA/uKg0uDMctWdZ0bL+L4jZzksUJpCjMA==",
+      "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.42.3",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.42.3.tgz",
-      "integrity": "sha512-/o52L/ngsGapcOUygWigvxzBo/bUVM4bubZMsUSZqZc+9sgjXZsgP/cwyggWUv3QOIqmbBrfSPgDLUh+Ofgi7Q==",
+      "version": "2.99.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.99.0.tgz",
+      "integrity": "sha512-SP9Sn9tsHDB7N4u2gT13rdeZJewE4xibAxasG7vOz+fYi92+XkMMbWNx0uGK53zKTnAnvTs16isRooyBy4sn5w==",
+      "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.63.0",
-        "@supabase/functions-js": "2.2.2",
-        "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.15.2",
-        "@supabase/realtime-js": "2.9.4",
-        "@supabase/storage-js": "2.5.5"
+        "@supabase/auth-js": "2.99.0",
+        "@supabase/functions-js": "2.99.0",
+        "@supabase/postgrest-js": "2.99.0",
+        "@supabase/realtime-js": "2.99.0",
+        "@supabase/storage-js": "2.99.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@swc/counter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
-    },
     "node_modules/@swc/helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
-      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
+      "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@swc/counter": "^0.1.3",
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.11.3.tgz",
+      "integrity": "sha512-vCU+OTylXN3hdC8RKg68tPlBPjjxtzon7Ys46MgrSLE+JhSjSTPvoQifV6DQJeJmA8Q3KT6CphJbejupx85vFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.11.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.11.3.tgz",
+      "integrity": "sha512-v2mrNSnMwnPJtcVqNvV0c5roGCBqeogN8jDtgtuHCphdwBasOZ17x8UV8qpHUh+u0MLfX43c0uUHKje0s+Zb0w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@types/node": {
       "version": "20.11.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
       "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/phoenix": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.4.tgz",
-      "integrity": "sha512-B34A7uot1Cv0XtaHRYDATltAdKx0BvVKNgYNqE4WjtPUa4VQJM7kxeXcVKaH+KS+kCmZ+6w+QaUdcljiheiBJA=="
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.12",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
-      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "devOptional": true
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.2.48",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.48.tgz",
-      "integrity": "sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==",
-      "devOptional": true,
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.2.18",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.18.tgz",
-      "integrity": "sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
-      "dependencies": {
-        "@types/react": "*"
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-YIoDCTH3Af6XM5VuwGG/QL/CJqga1Zm3NkU3HZ4ZHK2fRMPYP1VczsTUqtsf43PH/iJNVlPHAo2oWX7BSdB2Hw==",
-      "devOptional": true
     },
     "node_modules/@types/ws": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
-      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -2843,7 +3935,8 @@
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.17",
@@ -2863,6 +3956,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "browserslist": "^4.22.2",
         "caniuse-lite": "^1.0.30001578",
@@ -2881,15 +3975,23 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -2897,29 +3999,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "funding": [
         {
           "type": "opencollective",
@@ -2934,11 +4029,13 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2947,29 +4044,19 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
-    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001609",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001609.tgz",
-      "integrity": "sha512-JFPQs34lHKx1B5t1EpQpWH4c+29zIyn/haGsbpfq3suuV9v56enjFt23zqijxGTMwy1p/4H2tjnQMY+p1WoAyA==",
+      "version": "1.0.30001777",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
+      "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -2983,12 +4070,14 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -3012,6 +4101,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -3022,12 +4112,14 @@
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
     },
     "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3036,6 +4128,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -3048,6 +4141,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3058,12 +4152,14 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/color-string": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -3072,46 +4168,42 @@
     "node_modules/color2k": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
-      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==",
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz",
-      "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
+        "node": ">=18"
       },
-      "engines": {
-        "node": ">= 8"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -3120,76 +4212,85 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/detect-node-es": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
-    },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.735",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.735.tgz",
-      "integrity": "sha512-pkYpvwg8VyOTQAeBqZ7jsmpCjko1Qc6We1ZtZCjRyYbT5v4AIUKDy5cQTRotQlSSZmMr8jqpEt6JtOj5k7lR7A=="
-    },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+      "version": "1.5.307",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
+      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+      "license": "ISC"
     },
     "node_modules/encoding": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -3199,6 +4300,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -3207,17 +4309,19 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3225,33 +4329,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "bin": {
-        "flat": "cli.js"
-      }
-    },
-    "node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
       "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       },
@@ -3261,16 +4343,19 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "11.0.28",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.0.28.tgz",
-      "integrity": "sha512-j/vNYTCH5MX5sY/3dwMs00z1+qAqKX3iIHF762bwqlU814ooD5dDbuj3pA0LmIT5YqyryCkXEb/q+zRblin0lw==",
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
       "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
         "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/is-prop-valid": {
@@ -3289,6 +4374,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -3301,51 +4387,25 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/geist": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/geist/-/geist-1.3.0.tgz",
-      "integrity": "sha512-IoGBfcqVEYB4bEwsfHd35jF4+X9LHRPYZymHL4YOltHSs9LJa24DYs1Z7rEMQ/lsEvaAIc61Y9aUxgcJaQ8lrg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/geist/-/geist-1.7.0.tgz",
+      "integrity": "sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==",
+      "license": "SIL OPEN FONT LICENSE",
       "peerDependencies": {
-        "next": ">=13.2.0 <15.0.0-0"
-      }
-    },
-    "node_modules/get-nonce": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/glob": {
-      "version": "10.3.12",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.12.tgz",
-      "integrity": "sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.6",
-        "minimatch": "^9.0.1",
-        "minipass": "^7.0.4",
-        "path-scurry": "^1.10.2"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "next": ">=13.2.0"
       }
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -3353,15 +4413,11 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -3369,11 +4425,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -3381,34 +4447,39 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/intl-messageformat": {
-      "version": "10.5.11",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.11.tgz",
-      "integrity": "sha512-eYq5fkFBVxc7GIFDzpFQkDOZgNayNTQn4Oufe8jw6YY6OHVw70/4pA3FyCsQ0Gb2DnvEJEMmN2tOaXUGByM+kg==",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.2",
-        "@formatjs/fast-memoize": "2.2.0",
-        "@formatjs/icu-messageformat-parser": "2.7.6",
-        "tslib": "^2.4.0"
+    "node_modules/input-otp": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.1.tgz",
+      "integrity": "sha512-+yvpmKYKHi9jIGngxagY9oWiiblPB7+nEO75F2l2o4vs+6vpPZZmUl4tBNYuTCvQjhvEIbdNeJu70bhfYP2nbw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "loose-envify": "^1.0.0"
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -3417,11 +4488,15 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3431,22 +4506,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -3458,58 +4527,25 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
     },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    },
-    "node_modules/jackspeak": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
-      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/jiti": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
-      "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
-      }
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
-    "node_modules/legacy-swc-helpers": {
-      "name": "@swc/helpers",
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
       "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -3517,98 +4553,51 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    },
-    "node_modules/lodash.foreach": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "integrity": "sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ=="
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-    },
-    "node_modules/lodash.kebabcase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g=="
-    },
-    "node_modules/lodash.mapkeys": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapkeys/-/lodash.mapkeys-4.6.0.tgz",
-      "integrity": "sha512-0Al+hxpYvONWtg+ZqHpa/GaVzxuN3V7Xeo2p+bY06EaK/n+Y9R7nBePPN2o1LxmL0TWQSwP8LYZ008/hc9JzhA=="
-    },
-    "node_modules/lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg=="
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
-      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
-      "engines": {
-        "node": "14 || >=16.14"
-      }
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
       }
     },
-    "node_modules/minimatch": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "motion-utils": "^11.18.1"
       }
     },
-    "node_modules/minipass": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -3616,15 +4605,16 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -3633,40 +4623,40 @@
       }
     },
     "node_modules/next": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.1.tgz",
-      "integrity": "sha512-SF3TJnKdH43PMkCcErLPv+x/DY1YCklslk3ZmwaVoyUfDgHKexuKlf9sEfBQ69w+ue8jQ3msLb+hSj1T19hGag==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.12.tgz",
+      "integrity": "sha512-Fi/wQ4Etlrn60rz78bebG1i1SR20QxvV8tVp6iJspjLUSHcZoeUXCt+vmWoEcza85ElZzExK/jJ/F6SvtGktjA==",
+      "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.1",
-        "@swc/helpers": "0.5.5",
-        "busboy": "1.6.0",
+        "@next/env": "15.5.12",
+        "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
-        "graceful-fs": "^4.2.11",
         "postcss": "8.4.31",
-        "styled-jsx": "5.1.1"
+        "styled-jsx": "5.1.6"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.1",
-        "@next/swc-darwin-x64": "14.2.1",
-        "@next/swc-linux-arm64-gnu": "14.2.1",
-        "@next/swc-linux-arm64-musl": "14.2.1",
-        "@next/swc-linux-x64-gnu": "14.2.1",
-        "@next/swc-linux-x64-musl": "14.2.1",
-        "@next/swc-win32-arm64-msvc": "14.2.1",
-        "@next/swc-win32-ia32-msvc": "14.2.1",
-        "@next/swc-win32-x64-msvc": "14.2.1"
+        "@next/swc-darwin-arm64": "15.5.12",
+        "@next/swc-darwin-x64": "15.5.12",
+        "@next/swc-linux-arm64-gnu": "15.5.12",
+        "@next/swc-linux-arm64-musl": "15.5.12",
+        "@next/swc-linux-x64-gnu": "15.5.12",
+        "@next/swc-linux-x64-musl": "15.5.12",
+        "@next/swc-win32-arm64-msvc": "15.5.12",
+        "@next/swc-win32-x64-msvc": "15.5.12",
+        "sharp": "^0.34.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.41.2",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
@@ -3676,9 +4666,21 @@
         "@playwright/test": {
           "optional": true
         },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -3699,6 +4701,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -3709,14 +4712,16 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3725,6 +4730,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3733,6 +4739,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3741,47 +4748,28 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
-    "node_modules/path-scurry": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
-      "integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -3793,14 +4781,16 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/pirates": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -3823,6 +4813,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -3836,6 +4827,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -3849,18 +4841,25 @@
       }
     },
     "node_modules/postcss-js": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
-      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
       },
       "engines": {
         "node": "^12 || ^14 || >= 16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
       },
       "peerDependencies": {
         "postcss": "^8.4.21"
@@ -3880,6 +4879,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "lilconfig": "^3.0.0",
         "yaml": "^2.3.4"
@@ -3901,9 +4901,10 @@
       }
     },
     "node_modules/postcss-load-config/node_modules/lilconfig": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.1.tgz",
-      "integrity": "sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       },
@@ -3912,27 +4913,35 @@
       }
     },
     "node_modules/postcss-nested": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
-      "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.11"
+        "postcss-selector-parser": "^6.1.1"
       },
       "engines": {
         "node": ">=12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
       },
       "peerDependencies": {
         "postcss": "^8.2.14"
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
-      "integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3944,7 +4953,8 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -3963,111 +4973,35 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
-    },
-    "node_modules/ramda": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.1.tgz",
-      "integrity": "sha512-OfxIeWzd4xdUNxlWhgFazxsA/nl3mS4/jGZI5n00uWOoSSFRhC1b6gl6xvmzUamgmqELraWp0J/qqVlXYPDPyA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
+      ],
+      "license": "MIT"
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/react-remove-scroll": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.9.tgz",
-      "integrity": "sha512-bvHCLBrFfM2OgcrpPY2YW84sPdS2o2HKWJUf1xGyGLnSoEnOTOBpahIarjRuYtN0ryahCeP242yf+5TrBX/pZA==",
-      "dependencies": {
-        "react-remove-scroll-bar": "^2.3.6",
-        "react-style-singleton": "^2.2.1",
-        "tslib": "^2.1.0",
-        "use-callback-ref": "^1.3.0",
-        "use-sidecar": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-remove-scroll-bar": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
-      "integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
-      "dependencies": {
-        "react-style-singleton": "^2.2.1",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-style-singleton": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
-      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
-      "dependencies": {
-        "get-nonce": "^1.0.0",
-        "invariant": "^2.2.4",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
+        "react": "^19.2.4"
       }
     },
     "node_modules/react-textarea-autosize": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz",
-      "integrity": "sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
@@ -4077,13 +5011,14 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
       }
@@ -4092,6 +5027,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -4099,31 +5035,31 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-    },
     "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
       },
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -4147,6 +5083,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -4155,170 +5092,105 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/scroll-into-view-if-needed": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.0.10.tgz",
       "integrity": "sha512-t44QCeDKAPf1mtQH3fYpWz8IM/DyvHLjs8wUvvwMYxk5moOqCzrMSxK6HQVD0QVmVjXFavoFIPRVrMuJPKAvtg==",
+      "license": "MIT",
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }
     },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "engines": {
-        "node": ">=14"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/styled-jsx": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
-      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
       "dependencies": {
         "client-only": "0.0.1"
       },
@@ -4326,7 +5198,7 @@
         "node": ">= 12.0.0"
       },
       "peerDependencies": {
-        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -4338,16 +5210,17 @@
       }
     },
     "node_modules/sucrase": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
-      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
-        "glob": "^10.3.10",
         "lines-and-columns": "^1.1.6",
         "mz": "^2.7.0",
         "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
         "ts-interface-checker": "^0.1.9"
       },
       "bin": {
@@ -4362,6 +5235,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4370,38 +5244,39 @@
       }
     },
     "node_modules/tailwind-merge": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.2.2.tgz",
-      "integrity": "sha512-tWANXsnmJzgw6mQ07nE3aCDkCK4QdT3ThPMCzawoYA2Pws7vSTCvz3Vrjg61jVUGfFZPJzxEP+NimbcW+EdaDw==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.24.0"
-      },
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
+      "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwind-variants": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-0.2.1.tgz",
-      "integrity": "sha512-2xmhAf4UIc3PijOUcJPA1LP4AbxhpcHuHM2C26xM0k81r0maAO6uoUSHl3APmvHZcY5cZCY/bYuJdfFa4eGoaw==",
-      "peer": true,
-      "dependencies": {
-        "tailwind-merge": "^2.2.0"
-      },
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-3.2.2.tgz",
+      "integrity": "sha512-Mi4kHeMTLvKlM98XPnK+7HoBPmf4gygdFmqQPaDivc3DpYS6aIY6KiG/PgThrGvii5YZJqRsPz0aPyhoFzmZgg==",
+      "license": "MIT",
       "engines": {
         "node": ">=16.x",
         "pnpm": ">=7.x"
       },
       "peerDependencies": {
+        "tailwind-merge": ">=3.0.0",
         "tailwindcss": "*"
+      },
+      "peerDependenciesMeta": {
+        "tailwind-merge": {
+          "optional": true
+        }
       }
     },
     "node_modules/tailwindcss": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
       "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
+      "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -4438,6 +5313,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
       }
@@ -4446,6 +5322,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -4453,10 +5330,56 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -4464,25 +5387,23 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "license": "Apache-2.0"
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4494,12 +5415,13 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "funding": [
         {
           "type": "opencollective",
@@ -4514,9 +5436,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -4525,19 +5448,13 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/use-callback-ref": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
-      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
+    "node_modules/use-composed-ref": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+      "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4545,20 +5462,13 @@
         }
       }
     },
-    "node_modules/use-composed-ref": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "license": "MIT",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4567,14 +5477,15 @@
       }
     },
     "node_modules/use-latest": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
-      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "license": "MIT",
       "dependencies": {
         "use-isomorphic-layout-effect": "^1.1.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4582,148 +5493,26 @@
         }
       }
     },
-    "node_modules/use-sidecar": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
-      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
-      "dependencies": {
-        "detect-node-es": "^1.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4741,14 +5530,18 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
-      "integrity": "sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,23 +6,23 @@
     "start": "next start"
   },
   "dependencies": {
-    "@nextui-org/react": "^2.2.10",
+    "@heroui/react": "^2.8.10",
     "@supabase/ssr": "latest",
     "@supabase/supabase-js": "latest",
     "autoprefixer": "10.4.17",
-    "framer-motion": "^11.0.28",
+    "framer-motion": "^11.5.6",
     "geist": "^1.2.1",
-    "next": "^14.2.1",
+    "next": "^15.5.12",
     "postcss": "8.4.33",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "tailwindcss": "3.4.1",
     "typescript": "5.3.3"
   },
   "devDependencies": {
     "@types/node": "20.11.5",
-    "@types/react": "18.2.48",
-    "@types/react-dom": "18.2.18",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "encoding": "^0.1.13"
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 // tailwind.config.js
-const { nextui } = require("@nextui-org/react");
+const { heroui } = require("@heroui/react");
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
@@ -7,11 +7,11 @@ module.exports = {
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./node_modules/@nextui-org/theme/dist/**/*.{js,ts,jsx,tsx}",
+    "./node_modules/@heroui/theme/dist/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
     extend: {},
   },
   darkMode: "class",
-  plugins: [nextui()],
+  plugins: [heroui()],
 };

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,8 +1,8 @@
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
-export const createClient = () => {
-  const cookieStore = cookies();
+export const createClient = async () => {
+  const cookieStore = await cookies();
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,


### PR DESCRIPTION
## Summary
- Upgrades Next.js 14→15.5.12, React 18→19, and replaces deprecated NextUI with HeroUI to resolve all 28 known security vulnerabilities (including critical CVE-2025-29927)
- Updates async APIs for Next.js 15 compatibility (`cookies()`, `createClient()`)
- Result: `npm audit` reports 0 vulnerabilities, `next build` passes cleanly

## Test plan
- [x] `npm audit` — 0 vulnerabilities
- [x] `next build` — compiles and generates pages successfully
- [ ] Verify app works in browser (`npm run dev`)