### PR TITLE
Add issue selection handler to fetch legislators

### DIFF
--- a/app/AutoListbox.tsx
+++ b/app/AutoListbox.tsx
@@ -53,55 +53,59 @@ export default function AutoListbox({
   if (!data) return null;
 
   return (
-    <div className="flex flex-col items-center gap-6">
-      <Autocomplete
-        defaultItems={data}
-        label={`Pick ${indefiniteArticle} ${topic}`}
-        placeholder={`Search for ${indefiniteArticle} ${topic}`}
-        className="max-w-xs"
-        onSelectionChange={handleSelectionChange}
-      >
-        {(datum) => (
-          <AutocompleteItem key={datum.name}>{datum.name}</AutocompleteItem>
-        )}
-      </Autocomplete>
-
-      {selectedIssue && (
-        <div className="w-full max-w-lg">
-          <h3 className="text-lg font-semibold mb-3">
-            Legislators for &ldquo;{selectedIssue}&rdquo;
-          </h3>
-          {loading ? (
-            <p className="text-sm text-gray-400">Loading...</p>
-          ) : legislators.length === 0 ? (
-            <p className="text-sm text-gray-400">No legislators linked to this issue yet.</p>
-          ) : (
-            <ul className="space-y-2">
-              {legislators.map((leg, i) => (
-                <li key={i} className="border border-gray-700 rounded-lg p-3">
-                  <div className="font-medium">{leg.full_name}</div>
-                  <div className="text-sm text-gray-400">
-                    {leg.type === "sen" ? "Senator" : "Representative"} · {leg.party} · {leg.state}
-                  </div>
-                  {leg.phone && (
-                    <div className="text-sm text-gray-400">{leg.phone}</div>
-                  )}
-                  {leg.contact_form && (
-                    <a
-                      href={leg.contact_form}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-sm text-blue-400 hover:underline"
-                    >
-                      Contact form
-                    </a>
-                  )}
-                </li>
-              ))}
-            </ul>
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-8 w-full items-start">
+      <div>
+        <Autocomplete
+          defaultItems={data}
+          label={`Pick ${indefiniteArticle} ${topic}`}
+          placeholder={`Search for ${indefiniteArticle} ${topic}`}
+          className="max-w-xs"
+          onSelectionChange={handleSelectionChange}
+        >
+          {(datum) => (
+            <AutocompleteItem key={datum.name}>{datum.name}</AutocompleteItem>
           )}
-        </div>
-      )}
+        </Autocomplete>
+      </div>
+
+      <div>
+        {selectedIssue && (
+          <>
+            <h3 className="text-lg font-semibold mb-3">
+              Legislators for &ldquo;{selectedIssue}&rdquo;
+            </h3>
+            {loading ? (
+              <p className="text-sm text-gray-400">Loading...</p>
+            ) : legislators.length === 0 ? (
+              <p className="text-sm text-gray-400">No legislators linked to this issue yet.</p>
+            ) : (
+              <ul className="space-y-2">
+                {legislators.map((leg, i) => (
+                  <li key={i} className="border border-gray-700 rounded-lg p-3">
+                    <div className="font-medium">{leg.full_name}</div>
+                    <div className="text-sm text-gray-400">
+                      {leg.type === "sen" ? "Senator" : "Representative"} · {leg.party} · {leg.state}
+                    </div>
+                    {leg.phone && (
+                      <div className="text-sm text-gray-400">{leg.phone}</div>
+                    )}
+                    {leg.contact_form && (
+                      <a
+                        href={leg.contact_form}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-sm text-blue-400 hover:underline"
+                      >
+                        Contact form
+                      </a>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,7 @@ export default async function Index() {
       <div className="mt-4 shrink gap-4">
         <Header />
       </div>
-      <div className="shrink-0 mt-12 mb-16">
+      <div className="shrink-0 mt-12 mb-16 w-full max-w-4xl px-4">
         <AutoListbox data={issues} indefiniteArticle="an" topic="Issue" />
       </div>
 


### PR DESCRIPTION
## Summary
- Adds `onSelectionChange` handler to the `AutoListbox` component
- On issue selection, queries `legislator_issue` join table to fetch linked legislators
- Displays legislators in a simple list with name, party, state, phone, and contact form link
- Shows empty state when no legislators are linked to the selected issue

Closes #7

## Test plan
- [x] Select an issue from the autocomplete dropdown
- [x] Verify legislators list appears below (empty state until data is seeded via #13)
- [x] Clear selection and verify list disappears
- [x] Verify build passes (`npm run build`)